### PR TITLE
Fix storage iam policy setting.

### DIFF
--- a/plugin/iamutil/iam_resources.go
+++ b/plugin/iamutil/iam_resources.go
@@ -219,6 +219,7 @@ type ServiceConfig struct {
 func (r *iamResourceImpl) SetIamPolicyRequest(p *Policy) (req *http.Request, err error) {
 	var data interface{}
 	switch strings.ToLower(r.config.Service.Name) {
+	// GCS uses a different payload than every other API.
 	case "storage":
 		data = p
 	default:

--- a/plugin/iamutil/iam_resources.go
+++ b/plugin/iamutil/iam_resources.go
@@ -216,10 +216,16 @@ type ServiceConfig struct {
 	ServicePath string
 }
 
-func (r *iamResourceImpl) SetIamPolicyRequest(p *Policy) (*http.Request, error) {
-	data := struct {
-		Policy *Policy `json:"policy,omitempty"`
-	}{Policy: p}
+func (r *iamResourceImpl) SetIamPolicyRequest(p *Policy) (req *http.Request, err error) {
+	var data interface{}
+	switch strings.ToLower(r.config.Service.Name) {
+	case "storage":
+		data = p
+	default:
+		data = struct {
+			Policy *Policy `json:"policy,omitempty"`
+		}{Policy: p}
+	}
 
 	buf, err := googleapi.WithoutDataWrapper.JSONReader(data)
 	if err != nil {
@@ -240,6 +246,12 @@ func (r *iamResourceImpl) constructRequest(httpMtd *HttpMethodCfg, data io.Reade
 		return nil, err
 	}
 
+	if req.Header == nil {
+		req.Header = make(http.Header)
+	}
+	if data != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	replacementMap := make(map[string]string)
 	for cId, replaceK := range httpMtd.ReplacementKeys {
 		rId, ok := r.relativeId.IdTuples[cId]


### PR DESCRIPTION
Fixes #3. Sadly, we can't detect this from the discovery doc and storage just does whatever it wants, including doing PUT data formats. 