### PR TITLE
Remove token leasing/revocation

### DIFF
--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -226,17 +226,19 @@ func (b *backend) pathRoleSetDelete(ctx context.Context, req *logical.Request, d
 
 	warnings := make([]string, 0)
 	if rs.AccountId != nil {
-		if err := b.deleteServiceAccount(ctx, iamAdmin, rs.AccountId); err != nil {
-			w := fmt.Sprintf("unable to delete service account '%s' (WAL entry to clean-up later has been added): %v", rs.AccountId.ResourceName(), err)
-			warnings = append(warnings, w)
-		}
 		if err := b.deleteTokenGenKey(ctx, iamAdmin, rs.TokenGen); err != nil {
-			w := fmt.Sprintf("unable to delete key for service account '%s' (WAL entry to clean-up later has been added): %v", rs.AccountId.ResourceName(), err)
+			w := fmt.Sprintf("unable to delete key under service account %q (WAL entry to clean-up later has been added): %v", rs.AccountId.ResourceName(), err)
 			warnings = append(warnings, w)
 		}
+
+		if err := b.deleteServiceAccount(ctx, iamAdmin, rs.AccountId); err != nil {
+			w := fmt.Sprintf("unable to delete service account %q (WAL entry to clean-up later has been added): %v", rs.AccountId.ResourceName(), err)
+			warnings = append(warnings, w)
+		}
+
 		if merr := b.removeBindings(ctx, iamHandle, rs.AccountId.EmailOrId, rs.Bindings); merr != nil {
 			for _, err := range merr.Errors {
-				w := fmt.Sprintf("unable to delete IAM policy bindings for service account '%s' (WAL entry to clean-up later has been added): %v", rs.AccountId.EmailOrId, err)
+				w := fmt.Sprintf("unable to delete IAM policy bindings for service account %q (WAL entry to clean-up later has been added): %v", rs.AccountId.EmailOrId, err)
 				warnings = append(warnings, w)
 			}
 		}

--- a/plugin/path_role_set_test.go
+++ b/plugin/path_role_set_test.go
@@ -499,10 +499,11 @@ func testRoleSetDelete(t *testing.T, td *testData, rsName, saName string) {
 	if err != nil {
 		t.Fatalf("unable to delete role set: %v", err)
 	} else if resp != nil {
+		if len(resp.Warnings) > 0 {
+			t.Logf("warnings returned from role set delete. Warnings:\n %s\n", strings.Join(resp.Warnings, ",\n"))
+		}
 		if resp.IsError() {
 			t.Fatalf("unable to delete role set: %v", resp.Error())
-		} else if len(resp.Warnings) > 0 {
-			t.Logf("warnings returned from role set delete. Warnings:\n %s\n", strings.Join(resp.Warnings, ",\n"))
 		}
 	}
 

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -75,7 +75,7 @@ func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Stora
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"token":              token.AccessToken,
-			"token_ttl":          time.Now().UTC().Sub(token.Expiry.UTC()),
+			"token_ttl":          token.Expiry.UTC().Sub(time.Now().UTC()),
 			"expires_at_seconds": token.Expiry.Unix(),
 		},
 	}, nil

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -75,8 +75,8 @@ func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Stora
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"token":           token.AccessToken,
-			"token_ttl":       time.Now().Sub(token.Expiry),
-			"expires_at_unix": token.Expiry.Unix(),
+			"token_ttl":       time.Now().UTC().Sub(token.Expiry.UTC()),
+			"expires_at_seconds": token.Expiry.Unix(),
 		},
 	}, nil
 }

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -75,7 +75,7 @@ func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Stora
 	return &logical.Response{
 		Data: map[string]interface{}{
 			"token":              token.AccessToken,
-			"token_ttl":          token.Expiry.UTC().Sub(time.Now().UTC()),
+			"token_ttl":          token.Expiry.UTC().Sub(time.Now().UTC()) / (time.Second),
 			"expires_at_seconds": token.Expiry.Unix(),
 		},
 	}, nil

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -74,8 +74,8 @@ func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Stora
 
 	return &logical.Response{
 		Data: map[string]interface{}{
-			"token":           token.AccessToken,
-			"token_ttl":       time.Now().UTC().Sub(token.Expiry.UTC()),
+			"token":              token.AccessToken,
+			"token_ttl":          time.Now().UTC().Sub(token.Expiry.UTC()),
 			"expires_at_seconds": token.Expiry.Unix(),
 		},
 	}, nil

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -5,40 +5,13 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
-	"time"
-
-	"strings"
-
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/vault/logical"
 	"github.com/hashicorp/vault/logical/framework"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
 )
-
-const (
-	SecretTypeAccessToken     = "access_token"
-	revokeAccessTokenEndpoint = "https://accounts.google.com/o/oauth2/revoke"
-	revokeTokenWarning        = `revocation request succeeded; however, due to how OAuth access works, the OAuth token might still be valid until it expires`
-)
-
-func secretAccessToken(b *backend) *framework.Secret {
-	return &framework.Secret{
-		Type: SecretTypeAccessToken,
-		Fields: map[string]*framework.FieldSchema{
-			"token": {
-				Type:        framework.TypeString,
-				Description: "OAuth2 token",
-			},
-		},
-		Renew:  b.secretAccessTokenRenew,
-		Revoke: b.secretAccessTokenRevoke,
-	}
-}
 
 func pathSecretAccessToken(b *backend) *framework.Path {
 	return &framework.Path{
@@ -74,53 +47,10 @@ func (b *backend) pathAccessToken(ctx context.Context, req *logical.Request, d *
 		return logical.ErrorResponse(fmt.Sprintf("role set '%s' cannot generate access tokens (has secret type %s)", rsName, rs.SecretType)), nil
 	}
 
-	return b.getSecretAccessToken(ctx, req.Storage, rs)
+	return b.secretAccessTokenResponse(ctx, req.Storage, rs)
 }
 
-func (b *backend) secretAccessTokenRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	// Renewal not allowed
-	return logical.ErrorResponse("short-term access tokens cannot be renewed - request new access token instead"), nil
-}
-
-func isInvalidTokenErr(err error) bool {
-	if gerr, ok := err.(*googleapi.Error); ok {
-		return gerr.Code == 400 && strings.Contains(gerr.Body, "invalid_token")
-	}
-	return false
-}
-
-func (b *backend) secretAccessTokenRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	tokenRaw, ok := req.Secret.InternalData["access_token"]
-	if !ok {
-		return nil, fmt.Errorf("secret is missing token internal data")
-	}
-
-	resp, err := http.Get(revokeAccessTokenEndpoint + fmt.Sprintf("?token=%s", url.QueryEscape(tokenRaw.(string))))
-	defer googleapi.CloseBody(resp)
-	if err == nil {
-		err = googleapi.CheckResponse(resp)
-	}
-
-	if err != nil {
-		// Token may have already expired on server; ignore if OAuth server returns error.
-		if isInvalidTokenErr(err) {
-			invalidTokenWarn := fmt.Sprintf("skipping manual token revocation because token has already been invalidated")
-			b.Logger().Warn(invalidTokenWarn)
-
-			return &logical.Response{
-				Warnings: []string{invalidTokenWarn},
-			}, nil
-		}
-
-		return logical.ErrorResponse(err.Error()), nil
-	}
-
-	return &logical.Response{
-		Warnings: []string{revokeTokenWarning},
-	}, nil
-}
-
-func (b *backend) getSecretAccessToken(ctx context.Context, s logical.Storage, rs *RoleSet) (*logical.Response, error) {
+func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Storage, rs *RoleSet) (*logical.Response, error) {
 	iamC, err := newIamAdmin(ctx, s)
 	if err != nil {
 		return nil, errwrap.Wrapf("could not create IAM Admin client: {{err}}", err)
@@ -141,20 +71,12 @@ func (b *backend) getSecretAccessToken(ctx context.Context, s logical.Storage, r
 		return logical.ErrorResponse(fmt.Sprintf("could not generate token: %v", err)), nil
 	}
 
-	secretD := map[string]interface{}{
-		"token": token.AccessToken,
-	}
-	internalD := map[string]interface{}{
-		"access_token":      token.AccessToken,
-		"key_name":          rs.TokenGen.KeyName,
-		"role_set":          rs.Name,
-		"role_set_bindings": rs.bindingHash(),
-	}
-	resp := b.Secret(SecretTypeAccessToken).Response(secretD, internalD)
-	resp.Secret.TTL = token.Expiry.Sub(time.Now())
-	resp.Secret.Renewable = false
-
-	return resp, err
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"token":      token.AccessToken,
+			"expires_at": token.Expiry,
+		},
+	}, nil
 }
 
 func (tg *TokenGenerator) getAccessToken(ctx context.Context, iamAdmin *iam.Service) (*oauth2.Token, error) {
@@ -181,4 +103,64 @@ func (tg *TokenGenerator) getAccessToken(ctx context.Context, iamAdmin *iam.Serv
 		return nil, errwrap.Wrapf("could not generate token: {{err}}", err)
 	}
 	return tkn, err
+}
+
+const deprecationWarning = `
+We have recently changed the behavior of the gcp/token/ endpoint to no longer generate leases. 
+This is due to limitations of the GCP API, as service account OAuth access tokens cannot be revoked.
+This access_token secret and associated lease were created by an older version of the GCP secrets engine
+and will be cleaned up now. Note that there is the chance that this access_token, if not already expired, 
+will still be valid up to one hour. 
+`
+
+const pathTokenHelpSyn = `Generate an OAuth2 access token under a specific role set.`
+const pathTokenHelpDesc = `
+This path will generate a new OAuth2 access token for accessing GCP APIs.
+A role set, binding IAM roles to specific GCP resources, will be specified 
+by name - for example, if this backend is mounted at "gcp",
+then "gcp/token/deploy" would generate tokens for the "deploy" role set.
+
+On the backend, each roleset is associated with a service account. 
+The token will be associated with this service account. Tokens have a 
+short-term lease (1-hour) associated with them but cannot be renewed.
+
+NOTE: As of Vault 0.11.2, we have changed the behavior of the token/ endpoint.
+Note that revocation is no longer supported and Vault will no longer create a
+lease for this type. 
+
+Please see backend documentation for more information: 
+https://www.vaultproject.io/docs/secrets/gcp/index.html
+`
+
+// EVERYTHING USING THIS SECRET TYPE IS CURRENTLY DEPRECATED.
+// We keep it to allow for clean up of access_token secrets/leases that may have be left over
+// by older versions of Vault.
+const SecretTypeAccessToken = "access_token"
+
+func secretAccessToken(b *backend) *framework.Secret {
+	return &framework.Secret{
+		Type: SecretTypeAccessToken,
+		Fields: map[string]*framework.FieldSchema{
+			"token": {
+				Type:        framework.TypeString,
+				Description: "OAuth2 token",
+			},
+		},
+		Renew:  b.secretAccessTokenRenew,
+		Revoke: b.secretAccessTokenRevoke,
+	}
+}
+
+// Renewal will still return an error, but return the warning in case as well.
+func (b *backend) secretAccessTokenRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	resp := logical.ErrorResponse("short-term access tokens cannot be renewed - request new access token instead")
+	resp.AddWarning(deprecationWarning)
+	return resp, nil
+}
+
+// Revoke will no-op and pass but warn the user. This is mostly to clean up old leases.
+// Any associated secret (access_token) has already expired and thus doesn't need to
+// actually be revoked,  or will expire within an hour and currently can't actually be revoked anyways.
+func (b *backend) secretAccessTokenRevoke(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	return &logical.Response{Warnings: []string{deprecationWarning}}, nil
 }

--- a/plugin/secrets_service_account_key.go
+++ b/plugin/secrets_service_account_key.go
@@ -213,18 +213,6 @@ func (b *backend) getSecretKey(ctx context.Context, s logical.Storage, rs *RoleS
 	return resp, nil
 }
 
-const pathTokenHelpSyn = `Generate an OAuth2 access token under a specific role set.`
-const pathTokenHelpDesc = `
-This path will generate a new OAuth2 access token for accessing GCP APIs.
-A role set, binding IAM roles to specific GCP resources, will be specified 
-by name - for example, if this backend is mounted at "gcp",
-then "gcp/token/deploy" would generate tokens for the "deploy" role set.
-
-On the backend, each roleset is associated with a service account. 
-The token will be associated with this service account. Tokens have a 
-short-term lease (1-hour) associated with them but cannot be renewed.
-`
-
 const pathServiceAccountKeySyn = `Generate an service account private key under a specific role set.`
 const pathServiceAccountKeyDesc = `
 This path will generate a new service account private key for accessing GCP APIs.

--- a/plugin/secrets_test.go
+++ b/plugin/secrets_test.go
@@ -183,13 +183,22 @@ func testGetToken(t *testing.T, td *testData, rsName string) (token string) {
 		t.Fatalf("expected response with secret, got response: %v", resp)
 	}
 
-	expiresAtRaw, ok := resp.Data["expires_at"]
+	expiresAtRaw, ok := resp.Data["expires_at_unix"]
 	if !ok {
 		t.Fatalf("expected 'expires_at' field to be returned")
 	}
-	expiresAt := expiresAtRaw.(time.Time)
+	expiresAt := time.Unix(expiresAtRaw.(int64), 0)
 	if time.Now().Sub(expiresAt) > time.Hour {
 		t.Fatalf("expected token to expire within an hour")
+	}
+
+	ttlRaw, ok := resp.Data["token_ttl"]
+	if !ok {
+		t.Fatalf("expected 'token_ttl' field to be returned")
+	}
+	tokenTtl := ttlRaw.(time.Duration)
+	if tokenTtl > time.Hour {
+		t.Fatalf("expected token ttl to be less than one hour")
 	}
 
 	tokenRaw, ok := resp.Data["token"]

--- a/plugin/secrets_test.go
+++ b/plugin/secrets_test.go
@@ -183,7 +183,7 @@ func testGetToken(t *testing.T, td *testData, rsName string) (token string) {
 		t.Fatalf("expected response with secret, got response: %v", resp)
 	}
 
-	expiresAtRaw, ok := resp.Data["expires_at_unix"]
+	expiresAtRaw, ok := resp.Data["expires_at_seconds"]
 	if !ok {
 		t.Fatalf("expected 'expires_at' field to be returned")
 	}

--- a/plugin/secrets_test.go
+++ b/plugin/secrets_test.go
@@ -197,7 +197,7 @@ func testGetToken(t *testing.T, td *testData, rsName string) (token string) {
 		t.Fatalf("expected 'token_ttl' field to be returned")
 	}
 	tokenTtl := ttlRaw.(time.Duration)
-	if tokenTtl > time.Hour {
+	if tokenTtl > time.Hour || tokenTtl < 0 {
 		t.Fatalf("expected token ttl to be less than one hour")
 	}
 


### PR DESCRIPTION
* Remove token leasing and revocation (i.e. don't return logical.Secret anymore)
* Also switched order of roleset deletion because IAM's deletion behavior for nonexistant keys switched from returning 404 to 403 (tests were failing)

TODO: Extensive documentation and warnings/notices for users potentially impacted. 

tl;dr: OAuth service account tokens do not allow for revocation (revocation requests silent no-op but return 200s)