### PR TITLE
Roleset return data consistency 

### DIFF
--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -144,7 +144,7 @@ func (b *backend) pathRoleSetRead(ctx context.Context, req *logical.Request, d *
 
 	if rs.AccountId != nil {
 		data["service_account_email"] = rs.AccountId.EmailOrId
-		data["service_account_project"] = rs.AccountId.Project
+		data["project"] = rs.AccountId.Project
 	}
 
 	if rs.TokenGen != nil && rs.SecretType == SecretTypeAccessToken {

--- a/plugin/path_role_set_test.go
+++ b/plugin/path_role_set_test.go
@@ -53,9 +53,9 @@ func TestPathRoleSet_Basic(t *testing.T) {
 		t.Fatalf("expected role set to have been created")
 	}
 	verifyReadData(t, respData, map[string]interface{}{
-		"secret_type":             SecretTypeAccessToken, // default
-		"service_account_project": td.Project,
-		"bindings":                expectedBinds,
+		"secret_type": SecretTypeAccessToken, // default
+		"project":     td.Project,
+		"bindings":    expectedBinds,
 	})
 
 	// Verify service account exists and has given role on project
@@ -102,9 +102,9 @@ func TestPathRoleSet_UpdateKeyRoleSet(t *testing.T) {
 		t.Fatalf("expected role set to have been created")
 	}
 	verifyReadData(t, respData, map[string]interface{}{
-		"secret_type":             SecretTypeKey,
-		"service_account_project": td.Project,
-		"bindings":                expectedBinds,
+		"secret_type": SecretTypeKey,
+		"project":     td.Project,
+		"bindings":    expectedBinds,
 	})
 
 	initSa := getServiceAccount(t, td.IamAdmin, respData)
@@ -152,9 +152,9 @@ func TestPathRoleSet_UpdateKeyRoleSet(t *testing.T) {
 		t.Fatalf("expected role set to have been created")
 	}
 	verifyReadData(t, respData, map[string]interface{}{
-		"secret_type":             SecretTypeKey, // default
-		"service_account_project": td.Project,
-		"bindings":                expectedBinds,
+		"secret_type": SecretTypeKey, // default
+		"project":     td.Project,
+		"bindings":    expectedBinds,
 	})
 
 	newSa := getServiceAccount(t, td.IamAdmin, respData)
@@ -263,10 +263,10 @@ func TestPathRoleSet_UpdateTokenRoleSet(t *testing.T) {
 		t.Fatalf("expected role set to have been created")
 	}
 	verifyReadData(t, respData, map[string]interface{}{
-		"secret_type":             SecretTypeAccessToken,
-		"service_account_project": td.Project,
-		"bindings":                expectedBinds,
-		"token_scopes":            []string{"https://www.googleapis.com/auth/cloud-platform"},
+		"secret_type":  SecretTypeAccessToken,
+		"project":      td.Project,
+		"bindings":     expectedBinds,
+		"token_scopes": []string{"https://www.googleapis.com/auth/cloud-platform"},
 	})
 
 	initSa := getServiceAccount(t, td.IamAdmin, respData)
@@ -298,9 +298,9 @@ func TestPathRoleSet_UpdateTokenRoleSet(t *testing.T) {
 		t.Fatalf("expected role set to have been created")
 	}
 	verifyReadData(t, respData, map[string]interface{}{
-		"secret_type":             SecretTypeAccessToken,
-		"service_account_project": td.Project,
-		"bindings":                expectedBinds,
+		"secret_type": SecretTypeAccessToken,
+		"project":     td.Project,
+		"bindings":    expectedBinds,
 		"token_scopes": []string{
 			"https://www.googleapis.com/auth/compute",
 			"https://www.googleapis.com/auth/compute.readonly",
@@ -571,9 +571,9 @@ func getServiceAccount(t *testing.T, iamAdmin *iam.Service, readData map[string]
 		t.Fatalf("expected role set to have service account email in returned read")
 	}
 
-	proj, ok := readData["service_account_project"]
+	proj, ok := readData["project"]
 	if !ok {
-		t.Fatalf("expected role set to have service account email in returned read")
+		t.Fatalf("expected role set to have service project in returned read")
 	}
 
 	saName := fmt.Sprintf(gcputil.ServiceAccountTemplate, proj, emailRaw.(string))


### PR DESCRIPTION
When reading a roleset, this changes one of the returned keys from 'service_account_project', to 'project' in order to match up with the input schema. This alignment is useful when using config management
tools to manage vault's configuration.