### PR TITLE
Remove redundant service_account/key verification before token generation

### DIFF
--- a/plugin/path_role_set_test.go
+++ b/plugin/path_role_set_test.go
@@ -690,8 +690,12 @@ func cleanup(t *testing.T, td *testData, rsName string, roles util.StringSet) {
 	for _, sa := range resp.Accounts {
 		if sa.DisplayName == fmt.Sprintf(serviceAccountDisplayNameTmpl, rsName) {
 			memberStrs.Add("serviceAccount:" + sa.Email)
-			t.Logf("[WARNING] had to clean up service account %s, should have been deleted (did test fail?)", sa.Name)
+			t.Logf("[WARNING] found test service account %s that should have been deleted (did test fail?)", sa.Name)
 			if _, err := td.IamAdmin.Projects.ServiceAccounts.Delete(sa.Name).Do(); err != nil {
+				if isGoogleApi404Error(err) {
+					// Most likely IAM finished deletion (propagation) after list call
+					continue
+				}
 				t.Logf("[WARNING] Auto-delete failed - manually clean up service account %s: %v", sa.Name, err)
 			}
 		}

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	"google.golang.org/api/iam/v1"
 )
 
 func pathSecretAccessToken(b *backend) *framework.Path {
@@ -41,11 +40,11 @@ func (b *backend) pathAccessToken(ctx context.Context, req *logical.Request, d *
 		return nil, err
 	}
 	if rs == nil {
-		return logical.ErrorResponse(fmt.Sprintf("role set '%s' does not exists", rsName)), nil
+		return logical.ErrorResponse("role set '%s' does not exists", rsName), nil
 	}
 
 	if rs.SecretType != SecretTypeAccessToken {
-		return logical.ErrorResponse(fmt.Sprintf("role set '%s' cannot generate access tokens (has secret type %s)", rsName, rs.SecretType)), nil
+		return logical.ErrorResponse("role set '%s' cannot generate access tokens (has secret type %s)", rsName, rs.SecretType), nil
 	}
 
 	return b.secretAccessTokenResponse(ctx, req.Storage, rs)
@@ -58,12 +57,12 @@ func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Stora
 	}
 
 	if rs.TokenGen == nil || rs.TokenGen.KeyName == "" {
-		return logical.ErrorResponse(fmt.Sprintf("invalid role set has no service account key, must be updated (path roleset/%s/rotate-key) before generating new secrets", rs.Name)), nil
+		return logical.ErrorResponse("invalid role set has no service account key, must be updated (path roleset/%s/rotate-key) before generating new secrets", rs.Name), nil
 	}
 
-	token, err := rs.TokenGen.getAccessToken(ctx, iamC)
+	token, err := rs.TokenGen.getAccessToken(ctx)
 	if err != nil {
-		return logical.ErrorResponse(fmt.Sprintf("unable to generate token - make sure your roleset service account and key are still valid: %v", err)), nil
+		return logical.ErrorResponse("unable to generate token - make sure your roleset service account and key are still valid: %v", err), nil
 	}
 
 	return &logical.Response{
@@ -75,7 +74,7 @@ func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Stora
 	}, nil
 }
 
-func (tg *TokenGenerator) getAccessToken(ctx context.Context, iamAdmin *iam.Service) (*oauth2.Token, error) {
+func (tg *TokenGenerator) getAccessToken(ctx context.Context) (*oauth2.Token, error) {
 	jsonBytes, err := base64.StdEncoding.DecodeString(tg.B64KeyJSON)
 	if err != nil {
 		return nil, errwrap.Wrapf("could not b64-decode key data: {{err}}", err)


### PR DESCRIPTION
Remove .get() calls agains IAM service accounts/keys to verify token roleset. 

- The token generation step fails immediately anyways if the account/key are not valid, so these would mostly be for redundancy/better error messages. 

- Context: User requested 20x quota increase for read QPS to IAM and we'd like to avoid that. The OAuth token endpoint is not quota-limited so don't add limits from IAM API. 

Flaky test improvements.

- In general, IAM API can have delayed propagation, so retry the initial token check, ignore clean-up warnings from delayed deletes, etc.




