### PR TITLE
Refactor roleset

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -2,10 +2,12 @@ package gcpsecrets
 
 import (
 	"context"
+	"github.com/hashicorp/vault/sdk/helper/logging"
+	"os"
 	"testing"
 	"time"
 
-	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -19,7 +21,13 @@ func getTestBackend(tb testing.TB) (logical.Backend, logical.Storage) {
 
 	config := logical.TestBackendConfig()
 	config.StorageView = new(logical.InmemStorage)
-	config.Logger = hclog.NewNullLogger()
+	logLevel := os.Getenv("VAULT_LOG")
+	if logLevel == "" {
+		config.Logger = hclog.NewNullLogger()
+	} else {
+		config.Logger = logging.NewVaultLogger(hclog.LevelFromString(logLevel))
+	}
+
 	config.System = &logical.StaticSystemView{
 		DefaultLeaseTTLVal: defaultLeaseTTLHr * time.Hour,
 		MaxLeaseTTLVal:     maxLeaseTTLHr * time.Hour,

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -2,7 +2,6 @@ package gcpsecrets
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
@@ -72,7 +71,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	if ok {
 		_, err := gcputil.Credentials(credentialsRaw.(string))
 		if err != nil {
-			return logical.ErrorResponse(fmt.Sprintf("invalid credentials JSON file: %v", err)), nil
+			return logical.ErrorResponse("invalid credentials JSON file: %v", err), nil
 		}
 		cfg.CredentialsRaw = credentialsRaw.(string)
 	}

--- a/plugin/role_set.go
+++ b/plugin/role_set.go
@@ -6,10 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"time"
-
-	"regexp"
-
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/go-multierror"
@@ -19,6 +15,9 @@ import (
 	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/logical"
 	"google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+	"regexp"
+	"time"
 )
 
 const (
@@ -51,12 +50,8 @@ func (rs *RoleSet) validate() error {
 		err = multierror.Append(err, fmt.Errorf("role set should have account associated"))
 	}
 
-	if len(rs.Bindings) == 0 {
-		err = multierror.Append(err, fmt.Errorf("role set bindings cannot be empty"))
-	}
-
-	if len(rs.RawBindings) == 0 {
-		err = multierror.Append(err, fmt.Errorf("role set raw bindings cannot be empty string"))
+	if rs.Bindings == nil {
+		err = multierror.Append(err, fmt.Errorf("role set bindings cannot be nil"))
 	}
 
 	switch rs.SecretType {
@@ -123,284 +118,336 @@ type TokenGenerator struct {
 	Scopes []string
 }
 
-func (b *backend) saveRoleSetWithNewAccount(ctx context.Context, s logical.Storage, rs *RoleSet, project string, newBinds ResourceBindings, scopes []string) (warning []string, err error) {
-	b.rolesetLock.Lock()
-	defer b.rolesetLock.Unlock()
-
-	httpC, err := b.HTTPClient(s)
-	if err != nil {
-		return nil, err
+func (b *backend) saveRoleSetWithNewAccount(
+	ctx context.Context, s logical.Storage, rs *RoleSet,
+	project, newAccountName string, newBinds ResourceBindings, scopes []string) (warning []string, err error) {
+	if rs == nil {
+		return nil, fmt.Errorf("expected non-nil roleset - GCP plugin error")
 	}
 
-	iamAdmin, err := b.IAMAdminClient(s)
-	if err != nil {
-		return nil, err
-	}
-
-	iamHandle := iamutil.GetIamHandle(httpC, useragent.String())
+	b.Logger().Debug("creating new account for roleset", "roleset", rs.Name)
 
 	oldAccount := rs.AccountId
 	oldBindings := rs.Bindings
 	oldTokenKey := rs.TokenGen
 
-	oldWals, err := rs.addWALsForCurrentAccount(ctx, s)
-	if err != nil {
-		tryDeleteWALs(ctx, s, oldWals...)
-		return nil, errwrap.Wrapf("failed to create WAL for cleaning up old account: {{err}}", err)
-	}
-
-	newWals := make([]string, 0, len(newBinds)+2)
-	walId, err := rs.newServiceAccount(ctx, s, iamAdmin, project)
-	if err != nil {
-		tryDeleteWALs(ctx, s, oldWals...)
-		return nil, err
-	}
-	newWals = append(newWals, walId)
-
-	binds := rs.Bindings
-	if newBinds != nil {
-		binds = newBinds
-		rs.Bindings = newBinds
-	}
-	walIds, err := rs.updateIamPolicies(ctx, s, b.iamResources, iamHandle, binds)
-	if err != nil {
-		tryDeleteWALs(ctx, s, oldWals...)
-		return nil, err
-	}
-	newWals = append(newWals, walIds...)
-
-	if rs.SecretType == SecretTypeAccessToken {
-		walId, err := rs.newKeyForTokenGen(ctx, s, iamAdmin, scopes)
+	if oldAccount != nil {
+		// Add WALs to make sure we clean up old account if needed
+		err := b.addWalsForAllAccountResources(ctx, s, rs.Name, oldAccount, oldBindings, oldTokenKey)
 		if err != nil {
-			tryDeleteWALs(ctx, s, oldWals...)
+			return nil, errwrap.Wrapf("failed to create WALs for cleaning up old account: {{err}}", err)
+		}
+	}
+
+	// Create new account
+	accountId, err := b.createNewAccountWithWal(ctx, s, rs.Name, project, newAccountName)
+	if err != nil {
+		return nil, err
+	}
+	rs.AccountId = accountId
+	b.Logger().Debug("set new accountId for roleset", "roleset", rs.Name, "accountId", accountId)
+
+	// Add resource bindings
+	err = b.addResourceBindingsWithWals(ctx, s, rs.Name, accountId, newBinds)
+	if err != nil {
+		return nil, err
+	}
+	rs.Bindings = newBinds
+	b.Logger().Debug("set bindings for roleset", "roleset", rs.Name, "bindings", newBinds)
+
+	// Create tokenGenerator if needed.
+	if rs.SecretType == SecretTypeAccessToken {
+		tokenGen, err := b.createAccountTokenGeneratorWithWal(ctx, s, rs.Name, accountId, scopes)
+		if err != nil {
 			return nil, err
 		}
-		newWals = append(newWals, walId)
+		rs.TokenGen = tokenGen
+		b.Logger().Debug("set new tokenGen for roleset", "roleset", rs.Name, "key", tokenGen.KeyName)
 	}
 
 	if err := rs.save(ctx, s); err != nil {
-		tryDeleteWALs(ctx, s, oldWals...)
-		return nil, err
+		return nil, errwrap.Wrapf("unable to save roleset to storage: {{err}}", err)
 	}
 
-	// Delete WALs for cleaning up new resources now that they have been saved.
-	tryDeleteWALs(ctx, s, newWals...)
-
-	// Try deleting old resources (WALs exist so we can ignore failures)
-	if oldAccount == nil || oldAccount.EmailOrId == "" {
-		// nothing to clean up
-		return nil, nil
+	if oldAccount != nil {
+		// Try deleting old resources (WALs exist so we can ignore failures)
+		return b.tryCleanAccountResources(ctx, s, rs.Name, oldAccount, oldBindings, oldTokenKey), nil
 	}
-
-	// Return any errors as warnings so user knows immediate cleanup failed
-	warnings := make([]string, 0)
-	if errs := b.removeBindings(ctx, iamHandle, oldAccount.EmailOrId, oldBindings); errs != nil {
-		warnings = make([]string, len(errs.Errors), len(errs.Errors)+2)
-		for idx, err := range errs.Errors {
-			warnings[idx] = fmt.Sprintf("unable to immediately delete old binding (WAL cleanup entry has been added): %v", err)
-		}
-	}
-	if err := b.deleteServiceAccount(ctx, iamAdmin, oldAccount); err != nil {
-		warnings = append(warnings, fmt.Sprintf("unable to immediately delete old account (WAL cleanup entry has been added): %v", err))
-	}
-	if err := b.deleteTokenGenKey(ctx, iamAdmin, oldTokenKey); err != nil {
-		warnings = append(warnings, fmt.Sprintf("unable to immediately delete old key (WAL cleanup entry has been added): %v", err))
-	}
-	return warnings, nil
+	return nil, nil
 }
 
-func (b *backend) saveRoleSetWithNewTokenKey(ctx context.Context, s logical.Storage, rs *RoleSet, scopes []string) (warning string, err error) {
-	b.rolesetLock.Lock()
-	defer b.rolesetLock.Unlock()
+func (b *backend) saveRolesetWithNewTokenGenerator(ctx context.Context, s logical.Storage, rs *RoleSet, scopes []string) (warnings []string, err error) {
+	if rs == nil {
+		return nil, fmt.Errorf("expected non-nil roleset - GCP plugin error")
+	}
 
 	if rs.SecretType != SecretTypeAccessToken {
-		return "", fmt.Errorf("a key is not saved or used for non-access-token role set '%s'", rs.Name)
+		return nil, fmt.Errorf("cannot rotate token gen - non-access-token role set %q has secret_type %q", rs.Name, rs.SecretType)
 	}
+	b.Logger().Debug("creating new token generator key for roleset", "roleset", rs.Name)
 
-	iamAdmin, err := b.IAMAdminClient(s)
-	if err != nil {
-		return "", err
-	}
-
-	oldKeyWalId := ""
-	if rs.TokenGen != nil {
-		if oldKeyWalId, err = framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
+	oldTokenGen := rs.TokenGen
+	if oldTokenGen != nil {
+		scopes = oldTokenGen.Scopes
+		if _, err := framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
 			RoleSet:            rs.Name,
-			KeyName:            rs.TokenGen.KeyName,
+			KeyName:            oldTokenGen.KeyName,
 			ServiceAccountName: rs.AccountId.ResourceName(),
 		}); err != nil {
-			return "", errwrap.Wrapf("unable to create WAL for deleting old key: {{err}}", err)
+			return nil, errwrap.Wrapf("unable to create WAL for deleting old key: {{err}}", err)
 		}
 	}
-	oldKeyGen := rs.TokenGen
 
-	newKeyWalId, err := rs.newKeyForTokenGen(ctx, s, iamAdmin, scopes)
-	if err != nil {
-		tryDeleteWALs(ctx, s, oldKeyWalId)
-		return "", err
-	}
-
-	if err := rs.save(ctx, s); err != nil {
-		tryDeleteWALs(ctx, s, oldKeyWalId)
-		return "", err
-	}
-
-	// Delete WALs for cleaning up new key now that it's been saved.
-	tryDeleteWALs(ctx, s, newKeyWalId)
-	if err := b.deleteTokenGenKey(ctx, iamAdmin, oldKeyGen); err != nil {
-		return errwrap.Wrapf("unable to delete old key (delayed cleaned up WAL entry added): {{err}}", err).Error(), nil
-	}
-
-	return "", nil
-}
-
-func (rs *RoleSet) addWALsForCurrentAccount(ctx context.Context, s logical.Storage) ([]string, error) {
-	if rs.AccountId == nil {
-		return nil, nil
-	}
-	wals := make([]string, 0, len(rs.Bindings)+2)
-	walId, err := framework.PutWAL(ctx, s, walTypeAccount, &walAccount{
-		RoleSet: rs.Name,
-		Id: gcputil.ServiceAccountId{
-			Project:   rs.AccountId.Project,
-			EmailOrId: rs.AccountId.EmailOrId,
-		},
-	})
+	tokenGen, err := b.createAccountTokenGeneratorWithWal(ctx, s, rs.Name, rs.AccountId, scopes)
 	if err != nil {
 		return nil, err
 	}
-	wals = append(wals, walId)
-	for resource, roles := range rs.Bindings {
-		var walId string
-		walId, err = framework.PutWAL(ctx, s, walTypeIamPolicy, &walIamPolicy{
-			RoleSet: rs.Name,
-			AccountId: gcputil.ServiceAccountId{
-				Project:   rs.AccountId.Project,
-				EmailOrId: rs.AccountId.EmailOrId,
-			},
-			Resource: resource,
-			Roles:    roles.ToSlice(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		wals = append(wals, walId)
+	rs.TokenGen = tokenGen
+
+	if err := rs.save(ctx, s); err != nil {
+		return nil, errwrap.Wrapf("unable to save roleset to storage: {{err}}", err)
 	}
 
-	if rs.SecretType == SecretTypeAccessToken && rs.TokenGen != nil {
-		walId, err := framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
-			RoleSet:            rs.Name,
-			KeyName:            rs.TokenGen.KeyName,
-			ServiceAccountName: rs.AccountId.ResourceName(),
-		})
-		if err != nil {
-			return nil, err
-		}
-		wals = append(wals, walId)
-	}
-	return wals, nil
+	return b.tryCleanAccountTokenGen(ctx, s, rs.Name, oldTokenGen), nil
 }
 
-func (rs *RoleSet) newServiceAccount(ctx context.Context, s logical.Storage, iamAdmin *iam.Service, project string) (string, error) {
-	saEmailPrefix := roleSetServiceAccountName(rs.Name)
-	projectName := fmt.Sprintf("projects/%s", project)
-	displayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, rs.Name)
-
-	walId, err := framework.PutWAL(ctx, s, walTypeAccount, &walAccount{
-		RoleSet: rs.Name,
-		Id: gcputil.ServiceAccountId{
-			Project:   project,
-			EmailOrId: fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saEmailPrefix, project),
-		},
-	})
-	if err != nil {
-		return "", errwrap.Wrapf("unable to create WAL entry for generating new service account: {{err}}", err)
+// Attempt to delete account, bindings, and tokenGen. This method assumes that WAL
+// entries have been added for each operation.
+func (b *backend) tryCleanAccountResources(ctx context.Context, s logical.Storage, rsName string, accountId *gcputil.ServiceAccountId, bindings ResourceBindings, tokenGen *TokenGenerator) []string {
+	if accountId == nil {
+		b.Logger().Debug("account cleanup called for nil account ID, skipping")
+		return nil
 	}
 
+	httpC, err := b.HTTPClient(s)
+	if err != nil {
+		return []string{fmt.Sprintf("unable to clean up unused resources, will try again later - could not create http client: %v", err)}
+	}
+
+	iamAdmin, err := iam.NewService(ctx, option.WithHTTPClient(httpC))
+	if err != nil {
+		return []string{fmt.Sprintf("unable to clean up unused resources, will try again later - could not create iam admin client: %v", err)}
+	}
+
+	iamHandle := iamutil.GetIamHandle(httpC, useragent.String())
+	warnings := make([]string, 0)
+	if tokenGen != nil {
+		if err := b.deleteTokenGenKey(ctx, iamAdmin, tokenGen); err != nil {
+			w := fmt.Sprintf("unable to clean up unused key %q, will try again later - %v", tokenGen.KeyName, err)
+			warnings = append(warnings, w)
+		}
+	}
+
+	if err := b.deleteServiceAccount(ctx, iamAdmin, accountId); err != nil {
+		w := fmt.Sprintf("unable to clean up unused account %q, will try again later - %v", accountId.ResourceName(), err)
+		warnings = append(warnings, w)
+	}
+
+	if merr := b.removeBindings(ctx, iamHandle, accountId.EmailOrId, bindings); merr != nil {
+		for _, err := range merr.Errors {
+			w := fmt.Sprintf("unable to clean up unused bindings for %q, will try again later - %v", accountId.EmailOrId, err)
+			warnings = append(warnings, w)
+		}
+	}
+
+	return warnings
+}
+
+// Attempt to delete only tokenGen. This method assumes that WAL
+// entries have been added for each operation.
+func (b *backend) tryCleanAccountTokenGen(ctx context.Context, s logical.Storage, rsName string, tokenGen *TokenGenerator) []string {
+	if tokenGen == nil {
+		b.Logger().Debug("token gen cleanup called for nil account ID, skipping")
+		return nil
+	}
+
+	httpC, err := b.HTTPClient(s)
+	if err != nil {
+		return []string{fmt.Sprintf("unable to clean up unused resources, will try again later - could not create http client: %v", err)}
+	}
+
+	iamAdmin, err := iam.NewService(ctx, option.WithHTTPClient(httpC))
+	if err != nil {
+		return []string{fmt.Sprintf("unable to clean up unused resources, will try again later - could not create iam admin client: %v", err)}
+	}
+
+	warnings := make([]string, 0)
+	if err := b.deleteTokenGenKey(ctx, iamAdmin, tokenGen); err != nil {
+		w := fmt.Sprintf("unable to clean up unused key %q, will try again later - %v", tokenGen.KeyName, err)
+		warnings = append(warnings, w)
+	}
+	return warnings
+}
+
+// Add cleanup callbacks to WALs. They will delete account, bindings, and tokenGen
+// (account key) ONLY if they are not used by the roleset saved under the name.
+func (b *backend) addWalsForAllAccountResources(ctx context.Context, s logical.Storage, rsName string, accountId *gcputil.ServiceAccountId, bindings ResourceBindings, tokenGen *TokenGenerator) error {
+	if accountId == nil {
+		b.Logger().Debug("No WALs to add prior to deletion, given nil service account ID")
+		return nil
+	}
+
+	b.Logger().Debug("add WAL for account deletion", "walType", walTypeAccount, "account", accountId)
+	_, err := framework.PutWAL(ctx, s, walTypeAccount, &walAccount{
+		RoleSet: rsName,
+		Id:      *accountId,
+	})
+	if err != nil {
+		return errwrap.Wrapf("unable to create WAL entry to clean up service account: {{err}}", err)
+	}
+
+	for resName, roles := range bindings {
+		b.Logger().Debug("add WAL for removing binding", "walType", walTypeIamPolicy, "account", accountId, "resource", resName, "roles", roles)
+		_, err := framework.PutWAL(ctx, s, walTypeIamPolicy, &walIamPolicy{
+			RoleSet:   rsName,
+			AccountId: *accountId,
+			Resource:  resName,
+			Roles:     roles.ToSlice(),
+		})
+		if err != nil {
+			return errwrap.Wrapf("unable to create WAL entry to clean up service account bindings: {{err}}", err)
+		}
+	}
+
+	if tokenGen != nil {
+		b.Logger().Debug("add WAL for token gen deletion", "walType", walTypeAccount, "key", tokenGen.KeyName)
+		_, err := framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
+			RoleSet:            rsName,
+			ServiceAccountName: accountId.ResourceName(),
+			KeyName:            tokenGen.KeyName,
+		})
+		if err != nil {
+			return errwrap.Wrapf("unable to create WAL entry to clean up service account key: {{err}}", err)
+		}
+	}
+	return nil
+}
+
+func (b *backend) createNewAccountWithWal(ctx context.Context, s logical.Storage, rolesetName, project, newAccountName string) (*gcputil.ServiceAccountId, error) {
+	b.Logger().Debug("creating new account", "project", project, "newAccountName", newAccountName)
+
+	accountId := &gcputil.ServiceAccountId{
+		Project:   project,
+		EmailOrId: fmt.Sprintf("%s@%s.iam.gserviceaccount.com", newAccountName, project),
+	}
+	b.Logger().Debug("add WAL for account deletion", "walType", walTypeAccount, "account", accountId)
+	_, err := framework.PutWAL(ctx, s, walTypeAccount, &walAccount{
+		RoleSet: rolesetName,
+		Id:      *accountId,
+	})
+	if err != nil {
+		return nil, errwrap.Wrapf("unable to create WAL entry to clean up service account: {{err}}", err)
+	}
+
+	httpC, err := b.HTTPClient(s)
+	if err != nil {
+		return nil, errwrap.Wrapf("could not create http client: {{err}}", err)
+	}
+
+	iamAdmin, err := iam.NewService(ctx, option.WithHTTPClient(httpC))
+	if err != nil {
+		return nil, errwrap.Wrapf("could not create IAM admin client: {{err}}", err)
+	}
+
+	projectName := fmt.Sprintf("projects/%s", project)
+	displayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, rolesetName)
 	sa, err := iamAdmin.Projects.ServiceAccounts.Create(
 		projectName, &iam.CreateServiceAccountRequest{
-			AccountId:      saEmailPrefix,
+			AccountId:      newAccountName,
 			ServiceAccount: &iam.ServiceAccount{DisplayName: displayName},
 		}).Do()
 	if err != nil {
-		return walId, errwrap.Wrapf(fmt.Sprintf("unable to create new service account under project '%s': {{err}}", projectName), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("unable to create new service account under project '%s': {{err}}", projectName), err)
 	}
-	rs.AccountId = &gcputil.ServiceAccountId{
-		Project:   project,
+	return &gcputil.ServiceAccountId{
+		Project:   sa.ProjectId,
 		EmailOrId: sa.Email,
-	}
-	return walId, nil
+	}, nil
 }
 
-func (rs *RoleSet) newKeyForTokenGen(ctx context.Context, s logical.Storage, iamAdmin *iam.Service, scopes []string) (string, error) {
-	walId, err := framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
-		RoleSet:            rs.Name,
-		KeyName:            "",
-		ServiceAccountName: rs.AccountId.ResourceName(),
-	})
+func (b *backend) createAccountTokenGeneratorWithWal(ctx context.Context, s logical.Storage, rolesetName string,
+	account *gcputil.ServiceAccountId, scopes []string) (*TokenGenerator, error) {
+	if account == nil {
+		return nil, fmt.Errorf("cannot create token gen for nil accountId")
+	}
+	b.Logger().Debug("creating token generator", "account", account.ResourceName(), "scopes", scopes)
+
+	httpC, err := b.HTTPClient(s)
 	if err != nil {
-		return "", err
+		return nil, errwrap.Wrapf("could not create http client: {{err}}", err)
 	}
 
-	key, err := iamAdmin.Projects.ServiceAccounts.Keys.Create(rs.AccountId.ResourceName(),
+	iamAdmin, err := iam.NewService(ctx, option.WithHTTPClient(httpC))
+	if err != nil {
+		return nil, errwrap.Wrapf("could not create IAM admin client: {{err}}", err)
+	}
+
+	key, err := iamAdmin.Projects.ServiceAccounts.Keys.Create(
+		account.ResourceName(),
 		&iam.CreateServiceAccountKeyRequest{
 			PrivateKeyType: privateKeyTypeJson,
 		}).Do()
 	if err != nil {
-		framework.DeleteWAL(ctx, s, walId)
-		return "", err
+		return nil, errwrap.Wrapf("unable to create service account key: {{err}}", err)
 	}
-	rs.TokenGen = &TokenGenerator{
+
+	// In case the roleset does not have this saved later, we add a WAL.
+	b.Logger().Debug("add WAL for cleaning up token gen key", "walType", walTypeAccountKey, "key", key.Name)
+	_, err = framework.PutWAL(ctx, s, walTypeAccountKey, &walAccountKey{
+		RoleSet:            rolesetName,
+		ServiceAccountName: account.ResourceName(),
+		KeyName:            key.Name,
+	})
+	if err != nil {
+		b.Logger().Error("unable to create WAL entry to clean up service account key %q in case of error, may need to be done manually", key.Name)
+	}
+
+	return &TokenGenerator{
 		KeyName:    key.Name,
 		B64KeyJSON: key.PrivateKeyData,
 		Scopes:     scopes,
-	}
-	return walId, nil
+	}, nil
 }
 
-func (rs *RoleSet) updateIamPolicies(ctx context.Context, s logical.Storage, enabledIamResources iamutil.IamResourceParser, iamHandle *iamutil.IamHandle, rb ResourceBindings) ([]string, error) {
-	wals := make([]string, 0, len(rb))
-	for rName, roles := range rb {
-		walId, err := framework.PutWAL(ctx, s, walTypeIamPolicy, &walIamPolicy{
-			RoleSet: rs.Name,
-			AccountId: gcputil.ServiceAccountId{
-				Project:   rs.AccountId.Project,
-				EmailOrId: rs.AccountId.EmailOrId,
-			},
-			Resource: rName,
-			Roles:    roles.ToSlice(),
-		})
-		if err != nil {
-			return wals, err
-		}
+func (b *backend) addResourceBindingsWithWals(ctx context.Context, s logical.Storage, rolesetName string,
+	account *gcputil.ServiceAccountId, bindings ResourceBindings) error {
 
+	b.Logger().Debug("adding resource bindings", "account", account.ResourceName(), "bindings", bindings.asOutput())
+
+	httpC, err := b.HTTPClient(s)
+	if err != nil {
+		return errwrap.Wrapf("could not create http client: {{err}}", err)
+	}
+	iamHandle := iamutil.GetIamHandle(httpC, useragent.String())
+
+	enabledIamResources := b.iamResources
+	for rName, roles := range bindings {
 		resource, err := enabledIamResources.Parse(rName)
 		if err != nil {
-			return wals, err
+			return err
 		}
 
 		p, err := iamHandle.GetIamPolicy(ctx, resource)
 		if err != nil {
-			return wals, err
+			return err
 		}
 
 		changed, newP := p.AddBindings(&iamutil.PolicyDelta{
 			Roles: roles,
-			Email: rs.AccountId.EmailOrId,
+			Email: account.EmailOrId,
 		})
 		if !changed || newP == nil {
 			continue
 		}
 
 		if _, err := iamHandle.SetIamPolicy(ctx, resource, newP); err != nil {
-			return wals, err
+			return err
 		}
-		wals = append(wals, walId)
 	}
-	return wals, nil
+	return nil
 }
 
-func roleSetServiceAccountName(rsName string) (name string) {
+func randomServiceAccountName(rsName string) (name string) {
 	// Sanitize role name
 	reg := regexp.MustCompile("[^a-zA-Z0-9-]+")
 	rsName = reg.ReplaceAllString(rsName, "-")

--- a/plugin/secrets_service_account_key.go
+++ b/plugin/secrets_service_account_key.go
@@ -78,11 +78,11 @@ func (b *backend) pathServiceAccountKey(ctx context.Context, req *logical.Reques
 		return nil, err
 	}
 	if rs == nil {
-		return logical.ErrorResponse(fmt.Sprintf("role set '%s' does not exists", rsName)), nil
+		return logical.ErrorResponse("role set '%s' does not exists", rsName), nil
 	}
 
 	if rs.SecretType != SecretTypeKey {
-		return logical.ErrorResponse(fmt.Sprintf("role set '%s' cannot generate service account keys (has secret type %s)", rsName, rs.SecretType)), nil
+		return logical.ErrorResponse("role set '%s' cannot generate service account keys (has secret type %s)", rsName, rs.SecretType), nil
 	}
 
 	return b.getSecretKey(ctx, req.Storage, rs, keyType, keyAlg)
@@ -129,12 +129,12 @@ func (b *backend) verifySecretServiceKeyExists(ctx context.Context, req *logical
 	// Verify role set was not deleted.
 	rs, err := getRoleSet(rsName.(string), ctx, req.Storage)
 	if err != nil {
-		return logical.ErrorResponse(fmt.Sprintf("could not find role set '%v' for secret", rsName)), nil
+		return logical.ErrorResponse("could not find role set '%v' for secret", rsName), nil
 	}
 
 	// Verify role set bindings have not changed since secret was generated.
 	if rs.bindingHash() != bindingSum.(string) {
-		return logical.ErrorResponse(fmt.Sprintf("role set '%v' bindings were updated since secret was generated, cannot renew", rsName)), nil
+		return logical.ErrorResponse("role set '%v' bindings were updated since secret was generated, cannot renew", rsName), nil
 	}
 
 	// Verify service account key still exists.
@@ -143,7 +143,7 @@ func (b *backend) verifySecretServiceKeyExists(ctx context.Context, req *logical
 		return logical.ErrorResponse("could not confirm key still exists in GCP"), nil
 	}
 	if k, err := iamAdmin.Projects.ServiceAccounts.Keys.Get(keyName.(string)).Do(); err != nil || k == nil {
-		return logical.ErrorResponse(fmt.Sprintf("could not confirm key still exists in GCP: %v", err)), nil
+		return logical.ErrorResponse("could not confirm key still exists in GCP: %v", err), nil
 	}
 	return nil, nil
 }
@@ -161,7 +161,7 @@ func (b *backend) secretKeyRevoke(ctx context.Context, req *logical.Request, d *
 
 	_, err = iamAdmin.Projects.ServiceAccounts.Keys.Delete(keyNameRaw.(string)).Do()
 	if err != nil && !isGoogleAccountKeyNotFoundErr(err) {
-		return logical.ErrorResponse(fmt.Sprintf("unable to delete service account key: %v", err)), nil
+		return logical.ErrorResponse("unable to delete service account key: %v", err), nil
 	}
 
 	return nil, nil
@@ -183,7 +183,7 @@ func (b *backend) getSecretKey(ctx context.Context, s logical.Storage, rs *RoleS
 
 	account, err := rs.getServiceAccount(iamC)
 	if err != nil {
-		return logical.ErrorResponse(fmt.Sprintf("roleset service account was removed - role set must be updated (write to roleset/%s/rotate) before generating new secrets", rs.Name)), nil
+		return logical.ErrorResponse("roleset service account was removed - role set must be updated (write to roleset/%s/rotate) before generating new secrets", rs.Name), nil
 	}
 
 	key, err := iamC.Projects.ServiceAccounts.Keys.Create(

--- a/plugin/util/parse_bindings.go
+++ b/plugin/util/parse_bindings.go
@@ -31,6 +31,10 @@ func BindingsHCL(bindings map[string]StringSet) (string, error) {
 }
 
 func ParseBindings(bindingsStr string) (map[string]StringSet, error) {
+	if bindingsStr == "" {
+		return map[string]StringSet{}, nil
+	}
+
 	// Try to base64 decode
 	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(bindingsStr))
 	decoded, b64err := ioutil.ReadAll(decoder)


### PR DESCRIPTION
As a precursor to adding two new fields, I wanted to refactor the roleset code.

Some larger changes:
- Separated `pathRoleSetCreateUpdate` into two paths: this will be very helpful with more fields and the code was starting to get confusing.
- Allow empty `bindings` (param must still be given, just as an empty string, to differentiate in update between "i want to set to none" and "i don't want to change it")
- Code no longer try to remove WALs that are not being used (i.e. we successfully deleted an account so we removed the WALs for rolling it back). The WAL callbacks check to make sure a roleset in storage isn't still using a resource (account/key/binding), so there's no harm in having them other than maybe more calls to storage, and the removal code required specific order requirements, which we already have enough of. 

Also:
- removed logical.ErrorResponse(fmt.Sprintf(...)) usage for new ErrorResponse()
- changed log level handling for tests

