### PR TITLE
Fixes to WAL rollback for service account keys

### DIFF
--- a/plugin/path_config_rotate_root_test.go
+++ b/plugin/path_config_rotate_root_test.go
@@ -170,11 +170,11 @@ func TestConfigRotateRootUpdate(t *testing.T) {
 			t.Errorf("missing private_key_id")
 		}
 
-			// Make sure we delete the stored key, whether it was rotated or not (retry will not error)
+		// Make sure we delete the stored key, whether it was rotated or not (retry will not error)
 		defer tryCleanupKey(t, iamAdmin, fmt.Sprintf(gcputil.ServiceAccountKeyTemplate,
-				newCreds.ProjectId,
-				newCreds.ClientEmail,
-				privateKeyId))
+			newCreds.ProjectId,
+			newCreds.ClientEmail,
+			privateKeyId))
 
 		if privateKeyId == newCreds.PrivateKeyId {
 			t.Errorf("creds were not rotated")


### PR DESCRIPTION
Also fmt

 #52 changed this to return if the roleset is nil, but we actually still want to clean the keys in the situation even if the roleset is no longer being used (e.g. got error before we saved the roleset but the service account and key were created). 

In practice I think in any case where the roleset is nil but the key isn't, there was also a service account WAL to clean up the unused account (which then cleaned the key) so it's not a big deal.