### PR TITLE
Handle version 3 policies for Resource Manager IAM requests ([projects, folders, organziations].getIamPolicy)

### DIFF
--- a/plugin/iamutil/iam_policy.go
+++ b/plugin/iamutil/iam_policy.go
@@ -13,11 +13,19 @@ const (
 type Policy struct {
 	Bindings []*Binding `json:"bindings,omitempty"`
 	Etag     string     `json:"etag,omitempty"`
+	Version  int        `json:"version,omitempty"`
 }
 
 type Binding struct {
-	Members []string `json:"members,omitempty"`
-	Role    string   `json:"role,omitempty"`
+	Members   []string   `json:"members,omitempty"`
+	Role      string     `json:"role,omitempty"`
+	Condition *Condition `json:"condition,omitempty"`
+}
+
+type Condition struct {
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	Expression  string `json:"expression,omitempty"`
 }
 
 type PolicyDelta struct {

--- a/plugin/iamutil/iam_resource.go
+++ b/plugin/iamutil/iam_resource.go
@@ -74,7 +74,15 @@ func (r *parsedIamResource) SetIamPolicyRequest(p *Policy) (req *http.Request, e
 	return r.constructRequest(&r.config.SetMethod, strings.NewReader(reqJson))
 }
 
+var requestPolicyVersion3 = `{"options": {"requestedPolicyVersion": 3}}`
+
 func (r *parsedIamResource) GetIamPolicyRequest() (*http.Request, error) {
+	// In order to support Resource Manager policies with conditional bindings,
+	// we need to request the policy version of 3. This request parameter is backwards compatible
+	// and will return version 1 policies if they are not yet updated to version 3.
+	if r.config != nil && r.config.Service == "cloudresourcemanager" {
+		return r.constructRequest(&r.config.GetMethod, strings.NewReader(requestPolicyVersion3))
+	}
 	return r.constructRequest(&r.config.GetMethod, nil)
 }
 

--- a/plugin/iamutil/iam_resource_test.go
+++ b/plugin/iamutil/iam_resource_test.go
@@ -124,3 +124,171 @@ func TestParsedIamResource(t *testing.T) {
 		}
 	}
 }
+
+func TestConditionalIamResource(t *testing.T) {
+	r := &parsedIamResource{
+		relativeId: &gcputil.RelativeResourceName{
+			Name:    "projects",
+			TypeKey: "cloudresourcemanager/projects",
+			IdTuples: map[string]string{
+				"projects": "project",
+			},
+			OrderedCollectionIds: []string{"cloudresourcemanager", "projects"},
+		},
+		config: &IamRestResource{
+			Name:               "projects",
+			TypeKey:            "cloudresourcemanager/projects",
+			Service:            "cloudresourcemanager",
+			IsPreferredVersion: true,
+			GetMethod: RestMethod{
+				HttpMethod: "GET",
+				BaseURL:    "https://cloudresourcemanager.googleapis.com/v1/",
+				Path:       "projects/{resource}:getIamPolicy",
+			},
+			SetMethod: RestMethod{
+				HttpMethod:    "POST",
+				BaseURL:       "https://cloudresourcemanager.googleapis.com/v1/",
+				Path:          "projects/{resource}:setIamPolicy",
+				RequestFormat: `{"policy":%s}`,
+			},
+			Parameters: []string{"resource"},
+			CollectionReplacementKeys: map[string]string{
+				"projects": "resource"},
+		},
+	}
+
+	getR, err := r.GetIamPolicyRequest()
+	if err != nil {
+		t.Fatalf("Could not construct GetIamPolicyRequest: %v", err)
+	}
+	expectedURLBase := "https://cloudresourcemanager.googleapis.com/v1/projects/project"
+	if getR.URL.String() != expectedURLBase+":getIamPolicy" {
+		t.Fatalf("expected get request URL %s, got %s", expectedURLBase+":getIamPolicy", getR.URL.String())
+	}
+	if getR.Method != "GET" {
+		t.Fatalf("expected get request method %s, got %s", "GET", getR.Method)
+	}
+	if getR.Body == nil {
+		t.Fatalf("expected non-nil get body")
+	}
+	data, err := ioutil.ReadAll(getR.Body)
+	if err != nil {
+		t.Fatalf("Error reading data from request body %v", err)
+	}
+	var body interface{}
+	err = json.Unmarshal(data, &body)
+	if err != nil {
+		t.Fatalf("Error parsing json from request body %s %v", string(data), err)
+	}
+	reqBody, ok := body.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Error asserting request body %s", string(data))
+	}
+	options, ok := reqBody["options"]
+	if !ok {
+		t.Fatalf("Couldn't find options in request body %s", string(data))
+	}
+
+	optionsMap, ok := options.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Error asserting options in request body %s", string(data))
+	}
+
+	requestedPolicyVersion, ok := optionsMap["requestedPolicyVersion"]
+	if !ok {
+		t.Fatalf("Couldn't find requestedPolicytVersion in options in request body %s", string(data))
+	}
+
+	version, ok := requestedPolicyVersion.(float64)
+	if !ok {
+		t.Fatalf("Error asserting requestedPolicyVersion in request body %s", string(data))
+	}
+
+	if version != 3 {
+		t.Fatalf("requestedPolicyVersion is not 3 in request body %s", string(data))
+	}
+
+	expectedP := &Policy{
+		Etag:    "atag",
+		Version: 3,
+		Bindings: []*Binding{
+			{
+				Members: []string{"user:myuser@google.com", "serviceAccount:myserviceaccount@iam.gserviceaccounts.com"},
+				Role:    "roles/arole",
+				Condition: &Condition{
+					Title:       "test",
+					Description: "",
+					Expression: "a==b",
+				},
+			},
+			{
+				Members: []string{"user:myuser@google.com"},
+				Role:    "roles/anotherrole",
+			},
+		},
+	}
+	setR, err := r.SetIamPolicyRequest(expectedP)
+	if err != nil {
+		t.Fatalf("Could not construct SetIamPolicyRequest: %v", err)
+	}
+
+	if setR.URL.String() != expectedURLBase+":setIamPolicy" {
+		t.Fatalf("expected set request URL %s, got %s", expectedURLBase+":setIamPolicy", getR.URL.String())
+	}
+	if setR.Method != "POST" {
+		t.Fatalf("expected set request method %s, got %s", "POST", getR.Method)
+	}
+	if setR.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("expected `Content Type = application/json` header in set request, headers: %+v", setR.Header)
+	}
+	if setR.Body == nil {
+		t.Fatalf("expected non-nil set body, actually nil")
+	}
+	data, err = ioutil.ReadAll(setR.Body)
+	if err != nil {
+		t.Fatalf("unable to read data from set request: %v", err)
+	}
+
+	actual := struct {
+		P *Policy `json:"policy,omitempty"`
+	}{}
+	if err := json.Unmarshal(data, &actual); err != nil {
+		t.Fatalf("unable to read policy from set request body: %v", err)
+	}
+	if actual.P.Etag != expectedP.Etag {
+		t.Fatalf("mismatch set request policy, expected %s, got %s", expectedP.Etag, actual.P.Etag)
+	}
+
+	if len(actual.P.Bindings) != len(expectedP.Bindings) {
+		t.Fatalf("mismatch set request policy bindings length, expected %+v, got %+v", expectedP.Bindings, actual.P.Bindings)
+	}
+
+	for i, expectB := range expectedP.Bindings {
+		actualB := actual.P.Bindings[i]
+		if expectB.Role != actualB.Role {
+			t.Errorf("expected bindings[%d] to have role %s, got %s", i, expectB.Role, actualB.Role)
+		}
+		if len(expectB.Members) != len(actualB.Members) {
+			t.Errorf("expected bindings[%d] to have members %+v, got %+v", i, expectB.Members, actualB.Members)
+		}
+		for memberI, expectM := range expectB.Members {
+			if expectM != actualB.Members[memberI] {
+				t.Errorf("expected bindings[%d], members[%d] to be %s, got %s", i, memberI, expectM, actualB.Members[memberI])
+			}
+		}
+		if expectB.Condition != nil {
+			if actualB.Condition == nil {
+				t.Errorf("expected bindings[%d] to have condition %s, got %s", i, expectB.Condition, actualB.Condition)
+			}
+			if expectB.Condition.Title != actualB.Condition.Title {
+				t.Errorf("expected bindings[%d] to have condition titled %s, got %s", i, expectB.Condition.Title, actualB.Condition.Title)
+			}
+			if expectB.Condition.Description != actualB.Condition.Description {
+				t.Errorf("expected bindings[%d] to have condition description %s, got %s", i, expectB.Condition.Description, actualB.Condition.Description)
+			}
+			if expectB.Condition.Expression != actualB.Condition.Expression {
+				t.Errorf("expected bindings[%d] to have condition expression %s, got %s", i, expectB.Condition.Expression, actualB.Condition.Expression)
+			}
+		}
+	}
+}


### PR DESCRIPTION
We were running into this [error](https://github.com/hashicorp/vault-plugin-secrets-gcp/blob/da62b452d069dbbfc43fbb77ee42cdd516bb0ffc/plugin/iamutil/iam_handle.go#L31) when applying a new gcp roleset on an existing project.
```
* unable to get policy: googleapi: Error 400: Requested policy version (1) cannot be less than the existing policy version (3). For more information, please refer to https://cloud.google.com/iam/docs/policies#versions.
```

It turns out we had a project with a version 3 IAM policy set and when retrieving that policy with no request body [`options.requestedPolicyVersion`](https://cloud.google.com/resource-manager/reference/rest/Shared.Types/GetIamPolicyRequest#GetPolicyOptions) set it would return this error.  Providing the `requestedPolicyVersion` request parameter is backwards compatible and will return version 1 policies if they are not yet updated to version 3.  

I've added some tests and also ran the integration test, `TestIamHandle_ServiceAccount`, which hits this code path against a project with a version 3 IAM policy.  It works!  

This may also handle #70 as it essentially adds [IAM conditional](https://cloud.google.com/iam/docs/conditions-overview#syntax_overview) support for the cloudresourcemanager service (projects, folders, and organizations) IAM policies.