### PR TITLE
Truncate ServiceAccount display names longer than 100 characters

### DIFF
--- a/plugin/role_set.go
+++ b/plugin/role_set.go
@@ -22,9 +22,10 @@ import (
 )
 
 const (
-	serviceAccountMaxLen            = 30
-	serviceAccountDisplayNameMaxLen = 100
-	serviceAccountDisplayNameTmpl   = "Service account for Vault secrets backend role set %s"
+	serviceAccountMaxLen             = 30
+	serviceAccountDisplayNameHashLen = 8
+	serviceAccountDisplayNameMaxLen  = 100
+	serviceAccountDisplayNameTmpl    = "Service account for Vault secrets backend role set %s"
 )
 
 type RoleSet struct {
@@ -417,13 +418,12 @@ func roleSetServiceAccountName(rsName string) (name string) {
 }
 
 func roleSetServiceAccountDisplayName(name string) string {
-	hashLen := 8
 	fullDisplayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, name)
 	displayName := fullDisplayName
 	if len(fullDisplayName) > serviceAccountDisplayNameMaxLen {
-		truncIndex := serviceAccountDisplayNameMaxLen - hashLen
+		truncIndex := serviceAccountDisplayNameMaxLen - serviceAccountDisplayNameHashLen
 		h := fmt.Sprintf("%x", sha256.Sum256([]byte(fullDisplayName[truncIndex:])))
-		displayName = fullDisplayName[:truncIndex] + h[:hashLen]
+		displayName = fullDisplayName[:truncIndex] + h[:serviceAccountDisplayNameHashLen]
 	}
 	return displayName
 }

--- a/plugin/role_set_test.go
+++ b/plugin/role_set_test.go
@@ -1,0 +1,40 @@
+package gcpsecrets
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_roleSetServiceAccountDisplayName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "display name less than max size",
+			input: "display-name-that-is-not-truncated",
+			want:  fmt.Sprintf(serviceAccountDisplayNameTmpl, "display-name-that-is-not-truncated"),
+		},
+		{
+			name:  "display name greater than max size",
+			input: "display-name-that-is-really-long-vault-plugin-secrets-gcp-role-name",
+			want:  fmt.Sprintf(serviceAccountDisplayNameTmpl, "display-name-that-is-really-long-vault-pl43b18db3"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleSetServiceAccountDisplayName(tt.input)
+			checkDisplayNameLength(t, got)
+			if got != tt.want {
+				t.Errorf("roleSetServiceAccountDisplayName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func checkDisplayNameLength(t *testing.T, displayName string) {
+	if len(displayName) > serviceAccountDisplayNameMaxLen {
+		t.Errorf("expected display name to be less than or equal to %v. actual name '%v'", serviceAccountDisplayNameMaxLen, displayName)
+	}
+}


### PR DESCRIPTION
This will sha256(displayName[92:]) and concat the first 8
characters of the sha256 hash to the display name.

Fixes #68
