### PR TITLE
Update token scopes even when bindings aren't being changed

### DIFF
--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -362,6 +362,9 @@ func (b *backend) pathRoleSetCreateUpdate(ctx context.Context, req *logical.Requ
 	// If no new bindings or new bindings are exactly same as old bindings,
 	// just update the role set without rotating service account.
 	if !newBindings || rs.bindingHash() == getStringHash(bRaw.(string)) {
+		if rs.TokenGen != nil {
+			rs.TokenGen.Scopes = scopes
+		}
 		// Just save role with updated metadata:
 		if err := rs.save(ctx, req.Storage); err != nil {
 			return logical.ErrorResponse(err.Error()), nil


### PR DESCRIPTION
Fixes #45

# Contributor Checklist
- [x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
The docs already suggest this should be possible

- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
The acceptance test I added passed, but one test, `TestConfigRotateRootUpdate/rotate`, consistently fails, even without my changes. I don't think it's likely to be affected by my change, but if someone can suggest what I can do to fix the failure, I'd be happy to submit a clean test run.
```
$ GOOGLE_CLOUD_PROJECT=vault-gcp-auth-test GOOGLE_CREDENTIALS=~-1/secrets/vault-tester.json make test-acc TESTARGS=-v
?   	github.com/hashicorp/vault-plugin-secrets-gcp	[no test files]
=== RUN   TestConfigRotateRootUpdate
=== PAUSE TestConfigRotateRootUpdate
=== RUN   TestConfig
=== PAUSE TestConfig
=== RUN   TestPathRoleSet_Basic
--- PASS: TestPathRoleSet_Basic (4.97s)
=== RUN   TestPathRoleSet_UpdateKeyRoleSet
--- PASS: TestPathRoleSet_UpdateKeyRoleSet (6.66s)
=== RUN   TestPathRoleSet_RotateKeyRoleSet
    TestPathRoleSet_RotateKeyRoleSet: path_role_set_test.go:788: [WARNING] found test service account projects/vault-gcp-auth-test/serviceAccounts/vaulttest-rotatekey-1592241429@vault-gcp-auth-test.iam.gserviceaccount.com that should have been deleted, did test fail? Manually deleting...
    TestPathRoleSet_RotateKeyRoleSet: path_role_set_test.go:791: [WARNING] Disregard previous warning - manual delete returned 404, probably IAM eventual consistency
--- PASS: TestPathRoleSet_RotateKeyRoleSet (7.85s)
=== RUN   TestPathRoleSet_UpdateTokenRoleSetScopes
--- PASS: TestPathRoleSet_UpdateTokenRoleSetScopes (5.40s)
=== RUN   TestPathRoleSet_UpdateTokenRoleSet
    TestPathRoleSet_UpdateTokenRoleSet: path_role_set_test.go:788: [WARNING] found test service account projects/vault-gcp-auth-test/serviceAccounts/vaulttest-updatetok-1592241443@vault-gcp-auth-test.iam.gserviceaccount.com that should have been deleted, did test fail? Manually deleting...
    TestPathRoleSet_UpdateTokenRoleSet: path_role_set_test.go:791: [WARNING] Disregard previous warning - manual delete returned 404, probably IAM eventual consistency
--- PASS: TestPathRoleSet_UpdateTokenRoleSet (9.27s)
=== RUN   TestPathRoleSet_RotateTokenRoleSet
--- PASS: TestPathRoleSet_RotateTokenRoleSet (10.43s)
=== RUN   TestSecrets_GenerateAccessToken
--- PASS: TestSecrets_GenerateAccessToken (5.20s)
=== RUN   TestSecrets_GenerateKeyConfigTTL
2020/06/15 17:17:47 [DEBUG] test check failed with error Get "https://iam.googleapis.com/v1/projects/vault-gcp-auth-test/roles?alt=json&prettyPrint=false": oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant","error_description":"Invalid JWT Signature."} (attempt 0), sleeping one second before trying again
--- PASS: TestSecrets_GenerateKeyConfigTTL (7.10s)
=== RUN   TestSecrets_GenerateKeyTTLOverride
2020/06/15 17:17:54 [DEBUG] test check failed with error Get "https://iam.googleapis.com/v1/projects/vault-gcp-auth-test/roles?alt=json&prettyPrint=false": oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant","error_description":"Invalid JWT Signature."} (attempt 0), sleeping one second before trying again
--- PASS: TestSecrets_GenerateKeyTTLOverride (6.70s)
=== RUN   TestSecrets_GenerateKeyMaxTTLCheck
2020/06/15 17:18:01 [DEBUG] test check failed with error Get "https://iam.googleapis.com/v1/projects/vault-gcp-auth-test/roles?alt=json&prettyPrint=false": oauth2: cannot fetch token: 400 Bad Request
Response: {"error":"invalid_grant","error_description":"Invalid JWT Signature."} (attempt 0), sleeping one second before trying again
--- PASS: TestSecrets_GenerateKeyMaxTTLCheck (6.49s)
=== CONT  TestConfigRotateRootUpdate
=== RUN   TestConfigRotateRootUpdate/no_configuration
=== PAUSE TestConfigRotateRootUpdate/no_configuration
=== RUN   TestConfigRotateRootUpdate/config_with_no_credentials
=== PAUSE TestConfigRotateRootUpdate/config_with_no_credentials
=== RUN   TestConfigRotateRootUpdate/config_with_invalid_credentials
=== PAUSE TestConfigRotateRootUpdate/config_with_invalid_credentials
=== RUN   TestConfigRotateRootUpdate/rotate
=== PAUSE TestConfigRotateRootUpdate/rotate
=== CONT  TestConfigRotateRootUpdate/no_configuration
=== CONT  TestConfig
--- PASS: TestConfig (0.00s)
=== CONT  TestConfigRotateRootUpdate/rotate
=== CONT  TestConfigRotateRootUpdate/config_with_invalid_credentials
=== CONT  TestConfigRotateRootUpdate/config_with_no_credentials
    TestConfigRotateRootUpdate/rotate: path_config_rotate_root_test.go:165: failed to create new key: Post "https://iam.googleapis.com/v1/projects/-/serviceAccounts/vault-tester@vault-gcp-auth-test.iam.gserviceaccount.com/keys?alt=json&prettyPrint=false": oauth2: cannot fetch token: 400 Bad Request
        Response: {"error":"invalid_grant","error_description":"Invalid JWT Signature."}
--- FAIL: TestConfigRotateRootUpdate (0.00s)
    --- PASS: TestConfigRotateRootUpdate/no_configuration (0.00s)
    --- PASS: TestConfigRotateRootUpdate/config_with_invalid_credentials (0.00s)
    --- PASS: TestConfigRotateRootUpdate/config_with_no_credentials (0.00s)
    --- FAIL: TestConfigRotateRootUpdate/rotate (1.01s)
FAIL
FAIL	github.com/hashicorp/vault-plugin-secrets-gcp/plugin	71.087s
=== RUN   TestIamResource_ServiceAccount
--- PASS: TestIamResource_ServiceAccount (2.05s)
=== RUN   TestPolicyToDataset
--- PASS: TestPolicyToDataset (0.00s)
=== RUN   TestDatasetToPolicy
--- PASS: TestDatasetToPolicy (0.00s)
=== RUN   TestDatasetResource
--- PASS: TestDatasetResource (0.00s)
=== RUN   TestConditionalDatasetResource
--- PASS: TestConditionalDatasetResource (0.00s)
=== RUN   TestIamResource
--- PASS: TestIamResource (0.00s)
=== RUN   TestConditionalIamResource
--- PASS: TestConditionalIamResource (0.00s)
=== RUN   TestEnabledIamResources_RelativeName
--- PASS: TestEnabledIamResources_RelativeName (0.00s)
=== RUN   TestEnabledIamResources_FullName
--- PASS: TestEnabledIamResources_FullName (0.01s)
=== RUN   TestEnabledIamResources_SelfLink
--- PASS: TestEnabledIamResources_SelfLink (0.01s)
=== RUN   TestIamEnabledResources_ValidateGeneratedConfig
--- PASS: TestIamEnabledResources_ValidateGeneratedConfig (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil	2.080s
?   	github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil/internal	[no test files]
=== RUN   TestParseBindings
--- PASS: TestParseBindings (0.00s)
=== RUN   TestParseBindingsB64
--- PASS: TestParseBindingsB64 (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util	0.006s
?   	github.com/hashicorp/vault-plugin-secrets-gcp/scripts/gohelpers	[no test files]
FAIL
Makefile:35: recipe for target 'test-acc' failed
make: *** [test-acc] Error 1
```
- [x] Backwards compatible
