### PR TITLE
Backport 1.4.3: Update token scopes even when bindings aren't being changed

### DIFF
--- a/plugin/iamutil/iam_resource_test.go
+++ b/plugin/iamutil/iam_resource_test.go
@@ -218,7 +218,7 @@ func TestConditionalIamResource(t *testing.T) {
 				Condition: &Condition{
 					Title:       "test",
 					Description: "",
-					Expression: "a==b",
+					Expression:  "a==b",
 				},
 			},
 			{

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -362,6 +362,9 @@ func (b *backend) pathRoleSetCreateUpdate(ctx context.Context, req *logical.Requ
 	// If no new bindings or new bindings are exactly same as old bindings,
 	// just update the role set without rotating service account.
 	if !newBindings || rs.bindingHash() == getStringHash(bRaw.(string)) {
+		if rs.TokenGen != nil {
+			rs.TokenGen.Scopes = scopes
+		}
 		// Just save role with updated metadata:
 		if err := rs.save(ctx, req.Storage); err != nil {
 			return logical.ErrorResponse(err.Error()), nil


### PR DESCRIPTION
This PR backports a bug fix from https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/90.

Additionally includes a single character `make fmt` change in `iam_resource_test.go`. This was already present in this release branch prior to this backport. It was preventing `make dev` from completing successfully.
