### PR TITLE
fix: set policy version appropriately after roleset bindings have changed

### DIFF
--- a/plugin/iamutil/api_handle_test.go
+++ b/plugin/iamutil/api_handle_test.go
@@ -88,6 +88,10 @@ func verifyIamResource_GetSetPolicy(t *testing.T, resourceType string,
 		Email: creds.ClientEmail,
 	})
 
+	if p.Version != newP.Version {
+		t.Fatalf("expected policy version %d after adding bindings, got %d", p.Version, newP.Version)
+	}
+
 	if err != nil {
 		t.Fatalf("could not get IAM Policy for resource type '%s': %v", resourceType, err)
 	}

--- a/plugin/iamutil/iam_policy.go
+++ b/plugin/iamutil/iam_policy.go
@@ -103,6 +103,7 @@ func (p *Policy) ChangedBindings(toAdd *PolicyDelta, toRemove *PolicyDelta) (cha
 		return true, &Policy{
 			Bindings: newBindings,
 			Etag:     p.Etag,
+			Version:  p.Version,
 		}
 	}
 	return false, p


### PR DESCRIPTION
# Overview

Closes https://github.com/hashicorp/vault-plugin-secrets-gcp/issues/88

This PR ensures that the IAM policy version returned from `getIamPolicy` is the same one provided to `setIamPolicy` after bindings have been changed. The version number was not being copied into the new `Policy` struct when bindings changed, which led to the error:

```
Error writing data to gcp/roleset/my-key-roleset: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/gcp/roleset/my-key-roleset
Code: 400. Errors:

* unable to set policy: googleapi: Error 400: Specified policy version (1) cannot be less than the existing policy version (3). For more information, please refer to https://cloud.google.com/iam/docs/policies#versions.
```

I was able to reproduce the issue and verify the change in this PR fixes it.

# Related Issues/Pull Requests
- https://github.com/hashicorp/vault-plugin-secrets-gcp/issues/88
- https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/77

# Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
    - No docs needed for this fix
- [x] Backwards compatible
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
 
```
=== RUN   TestIamResource_ServiceAccount
--- PASS: TestIamResource_ServiceAccount (2.02s)
PASS
```
```
make test
?       github.com/hashicorp/vault-plugin-secrets-gcp   [no test files]
ok      github.com/hashicorp/vault-plugin-secrets-gcp/plugin    (cached)
ok      github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil    0.315s
?       github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil/internal   [no test files]
ok      github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util       (cached)
?       github.com/hashicorp/vault-plugin-secrets-gcp/scripts/gohelpers [no test files]
```