### PR TITLE
Backport 1.5.1: set policy version appropriately after roleset bindings have changed (#93)

### DIFF
--- a/plugin/iamutil/api_handle_test.go
+++ b/plugin/iamutil/api_handle_test.go
@@ -88,6 +88,10 @@ func verifyIamResource_GetSetPolicy(t *testing.T, resourceType string,
 		Email: creds.ClientEmail,
 	})
 
+	if p.Version != newP.Version {
+		t.Fatalf("expected policy version %d after adding bindings, got %d", p.Version, newP.Version)
+	}
+
 	if err != nil {
 		t.Fatalf("could not get IAM Policy for resource type '%s': %v", resourceType, err)
 	}

--- a/plugin/iamutil/iam_policy.go
+++ b/plugin/iamutil/iam_policy.go
@@ -103,6 +103,7 @@ func (p *Policy) ChangedBindings(toAdd *PolicyDelta, toRemove *PolicyDelta) (cha
 		return true, &Policy{
 			Bindings: newBindings,
 			Etag:     p.Etag,
+			Version:  p.Version,
 		}
 	}
 	return false, p


### PR DESCRIPTION
This PR backports #93 by cherry-picking c25987d130cb50ea3de151af4e5758cf16e69a46.