### PR TITLE
Backport 1.6.1: Truncate ServiceAccount display names longer than 100 characters (#87)

### DIFF
--- a/plugin/role_set.go
+++ b/plugin/role_set.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
-	serviceAccountMaxLen          = 30
-	serviceAccountDisplayNameTmpl = "Service account for Vault secrets backend role set %s"
+	serviceAccountMaxLen             = 30
+	serviceAccountDisplayNameHashLen = 8
+	serviceAccountDisplayNameMaxLen  = 100
+	serviceAccountDisplayNameTmpl    = "Service account for Vault secrets backend role set %s"
 )
 
 type RoleSet struct {
@@ -304,7 +306,7 @@ func (rs *RoleSet) addWALsForCurrentAccount(ctx context.Context, s logical.Stora
 func (rs *RoleSet) newServiceAccount(ctx context.Context, s logical.Storage, iamAdmin *iam.Service, project string) (string, error) {
 	saEmailPrefix := roleSetServiceAccountName(rs.Name)
 	projectName := fmt.Sprintf("projects/%s", project)
-	displayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, rs.Name)
+	displayName := roleSetServiceAccountDisplayName(rs.Name)
 
 	walId, err := framework.PutWAL(ctx, s, walTypeAccount, &walAccount{
 		RoleSet: rs.Name,
@@ -413,6 +415,17 @@ func roleSetServiceAccountName(rsName string) (name string) {
 		name = fmt.Sprintf("vault%s-%s", rsName[:len(rsName)-toTrunc], intSuffix)
 	}
 	return name
+}
+
+func roleSetServiceAccountDisplayName(name string) string {
+	fullDisplayName := fmt.Sprintf(serviceAccountDisplayNameTmpl, name)
+	displayName := fullDisplayName
+	if len(fullDisplayName) > serviceAccountDisplayNameMaxLen {
+		truncIndex := serviceAccountDisplayNameMaxLen - serviceAccountDisplayNameHashLen
+		h := fmt.Sprintf("%x", sha256.Sum256([]byte(fullDisplayName[truncIndex:])))
+		displayName = fullDisplayName[:truncIndex] + h[:serviceAccountDisplayNameHashLen]
+	}
+	return displayName
 }
 
 func getStringHash(bindingsRaw string) string {

--- a/plugin/role_set_test.go
+++ b/plugin/role_set_test.go
@@ -1,0 +1,40 @@
+package gcpsecrets
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_roleSetServiceAccountDisplayName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "display name less than max size",
+			input: "display-name-that-is-not-truncated",
+			want:  fmt.Sprintf(serviceAccountDisplayNameTmpl, "display-name-that-is-not-truncated"),
+		},
+		{
+			name:  "display name greater than max size",
+			input: "display-name-that-is-really-long-vault-plugin-secrets-gcp-role-name",
+			want:  fmt.Sprintf(serviceAccountDisplayNameTmpl, "display-name-that-is-really-long-vault-pl43b18db3"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleSetServiceAccountDisplayName(tt.input)
+			checkDisplayNameLength(t, got)
+			if got != tt.want {
+				t.Errorf("roleSetServiceAccountDisplayName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func checkDisplayNameLength(t *testing.T, displayName string) {
+	if len(displayName) > serviceAccountDisplayNameMaxLen {
+		t.Errorf("expected display name to be less than or equal to %v. actual name '%v'", serviceAccountDisplayNameMaxLen, displayName)
+	}
+}


### PR DESCRIPTION
This PR backports https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/87 into the release/vault-1.6.x branch.

* Truncate ServiceAccount display names longer than 100 characters

This will sha256(displayName[92:]) and concat the first 8
characters of the sha256 hash to the display name.

Fixes #68

* Move ServiceAccount display name hash length to constant

Co-authored-by: Calvin Leung Huang <cleung2010@gmail.com>
