### PR TITLE
Fix WAL entries persisting when gcp project no longer exists

### DIFF
--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -199,6 +199,9 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 
 	p, err := r.GetIamPolicy(ctx, apiHandle)
 	if err != nil {
+		if isGoogleAccountNotFoundErr(err) || isGoogleAccountUnauthorizedErr(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -222,8 +225,10 @@ func (b *backend) deleteServiceAccount(ctx context.Context, iamAdmin *iam.Servic
 	}
 
 	_, err := iamAdmin.Projects.ServiceAccounts.Delete(account.ResourceName()).Do()
-	if err != nil && (!isGoogleAccountNotFoundErr(err) || !isGoogleAccountUnauthorizedErr(err)) {
-		return errwrap.Wrapf("unable to delete service account: {{err}}", err)
+	if err != nil {
+		if !isGoogleAccountNotFoundErr(err) && !isGoogleAccountUnauthorizedErr(err) {
+			return errwrap.Wrapf("unable to delete service account: {{err}}", err)
+		}
 	}
 	return nil
 }
@@ -297,10 +302,12 @@ func isGoogleApiErrorWithCodes(err error, validErrCodes ...int) bool {
 	if err == nil {
 		return false
 	}
-	gErr, ok := err.(*googleapi.Error)
+	ok := errwrap.ContainsType(err, new(googleapi.Error))
 	if !ok {
 		return false
 	}
+
+	gErr := errwrap.GetType(err, new(googleapi.Error)).(*googleapi.Error)
 
 	for _, code := range validErrCodes {
 		if gErr.Code == code {


### PR DESCRIPTION
# Overview
This change seeks to remove lingering WAL issues, where WAL entries would continue to persist after the GCP project
was deleted. It seeks to prevent repeated API calls to GCP attempting to delete entities that no longer exist in GCP due
to a previous cleanup. The issue would manifest for some users where they would begin to receive errors from google saying they had attempted too many API calls, and were being throttled.

Outside of fixing that behavior, there should be no change to the user experience.

This will not have an update in docs because it is restoring a behavior that was assumed to exist already.

# Design of Change
This change fixed some of the logic surrounding the WALs of iam_policy and account objects, checking, at various points, for 404 or 403 errors being returned from Google's API.

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[x] Backwards compatible
