### PR TITLE
Backport - Fix WAL entries persisting when gcp project no longer exists (#104)

### DIFF
--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -199,6 +199,9 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 
 	p, err := r.GetIamPolicy(ctx, apiHandle)
 	if err != nil {
+		if isGoogleAccountNotFoundErr(err) || isGoogleAccountUnauthorizedErr(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -222,8 +225,10 @@ func (b *backend) deleteServiceAccount(ctx context.Context, iamAdmin *iam.Servic
 	}
 
 	_, err := iamAdmin.Projects.ServiceAccounts.Delete(account.ResourceName()).Do()
-	if err != nil && (!isGoogleAccountNotFoundErr(err) || !isGoogleAccountUnauthorizedErr(err)) {
-		return errwrap.Wrapf("unable to delete service account: {{err}}", err)
+	if err != nil {
+		if !isGoogleAccountNotFoundErr(err) && !isGoogleAccountUnauthorizedErr(err) {
+			return errwrap.Wrapf("unable to delete service account: {{err}}", err)
+		}
 	}
 	return nil
 }
@@ -297,10 +302,12 @@ func isGoogleApiErrorWithCodes(err error, validErrCodes ...int) bool {
 	if err == nil {
 		return false
 	}
-	gErr, ok := err.(*googleapi.Error)
+	ok := errwrap.ContainsType(err, new(googleapi.Error))
 	if !ok {
 		return false
 	}
+
+	gErr := errwrap.GetType(err, new(googleapi.Error)).(*googleapi.Error)
 
 	for _, code := range validErrCodes {
 		if gErr.Code == code {


### PR DESCRIPTION
This is a backport of #104 to move this for release to vault 1.6.2