### PR TITLE
Deprecate setting TTL/MaxTTL via /config path

### DIFF
--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -3,6 +3,7 @@ package gcpsecrets
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
@@ -15,30 +16,46 @@ func pathConfig(b *backend) *framework.Path {
 		Pattern: "config",
 		Fields: map[string]*framework.FieldSchema{
 			"credentials": {
-				Type:        framework.TypeString,
-				Description: `GCP IAM service account credentials JSON with permissions to create new service accounts and set IAM policies`,
+				Type: framework.TypeString,
+				Description: strings.TrimSpace(`
+Optional Google Cloud service account key credentials JSON.
+`),
 			},
 			"ttl": {
-				Type:        framework.TypeDurationSecond,
-				Description: "Default lease for generated keys. If <= 0, will use system default.",
+				Type:       framework.TypeDurationSecond,
+				Deprecated: true,
+				Description: strings.TrimSpace(`
+Default lease duration for secrets that support leasing. Setting this value is
+deprecated and will be removed in a future release. Use "vault secrets tune"
+instead.
+`),
 			},
 			"max_ttl": {
-				Type:        framework.TypeDurationSecond,
-				Description: "Maximum time a service account key is valid for. If <= 0, will use system default.",
+				Type:       framework.TypeDurationSecond,
+				Deprecated: true,
+				Description: strings.TrimSpace(`
+Default maximum duration for secrets that support leasing. Setting this value is
+deprecated and will be removed in a future release. Use "vault secrets tune"
+instead.
+`),
 			},
 		},
-
+		ExistenceCheck: b.configExistenceCheck(),
 		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation: &framework.PathOperation{
-				Callback: b.pathConfigRead,
-			},
-			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathConfigWrite,
-			},
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathConfigRead},
+			logical.CreateOperation: &framework.PathOperation{Callback: b.pathConfigWrite},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathConfigWrite},
 		},
-
-		HelpSynopsis:    pathConfigHelpSyn,
-		HelpDescription: pathConfigHelpDesc,
+		HelpSynopsis: strings.TrimSpace(`
+Configure the Google Cloud secrets engine.
+`),
+		HelpDescription: strings.TrimSpace(`
+This path configures the Google Cloud secrets engine. When running on Google
+Cloud or a platform that supports Workload Identity Federation, the Vault server
+will automatically use the underlying service account attached to the machine
+identity. In these circumstances, specifying the service account key credentials
+JSON is unnecessary.
+`),
 	}
 }
 
@@ -104,9 +121,22 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, dat
 	return nil, nil
 }
 
+func (b *backend) configExistenceCheck() framework.ExistenceFunc {
+	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (bool, error) {
+		cfg, err := getConfig(ctx, req.Storage)
+		if err != nil {
+			return false, err
+		}
+		return cfg != nil, nil
+	}
+}
+
 type config struct {
 	CredentialsRaw string
 
+	// TTL and MaxTTL are the default backend TTLs.
+	//
+	// Deprecated: Use "vault secrets tune" instead.
 	TTL    time.Duration
 	MaxTTL time.Duration
 }
@@ -128,12 +158,47 @@ func getConfig(ctx context.Context, s logical.Storage) (*config, error) {
 	return &cfg, err
 }
 
-const pathConfigHelpSyn = `
-Configure the GCP backend.
-`
+// adjustTTLsFromConfig extracts the current configuration and caps the ttl and
+// max_ttl on the provided secret at the max value in the configuration. If the
+// config has a value for the TTLs, it adds a warning to the response to push
+// the caller to use "vault secrets tune" instead.
+//
+// TODO(sethvargo): remove this in a future release.
+func adjustTTLsFromConfig(ctx context.Context, storage logical.Storage, resp *logical.Response) error {
+	cfg, err := getConfig(ctx, storage)
+	if err != nil {
+		return err
+	}
+	cfg.adjustTTLs(resp)
+	return nil
+}
 
-const pathConfigHelpDesc = `
-The GCP backend requires credentials for managing IAM service accounts and keys
-and IAM policies on various GCP resources. This endpoint is used to configure
-those credentials as well as default values for the backend in general.
-`
+// adjustTTLs adjusts the TTLs on the secret against the provided response. See
+// adjustTTLsFromConfig for more information.
+//
+// TODO(sethvargo): remove this in a future release.
+func (c *config) adjustTTLs(resp *logical.Response) {
+	if c == nil || resp == nil || resp.Secret == nil {
+		return
+	}
+
+	if ttl := c.TTL; ttl > 0 {
+		resp.AddWarning(`The Google Cloud secrets engine is using a ttl set via ` +
+			`the /config path. This approach is deprecated and will be removed in ` +
+			`a future release. Use "vault secrets tune" to set the ttl.`)
+
+		if resp.Secret.TTL > ttl {
+			resp.Secret.TTL = ttl
+		}
+	}
+
+	if ttl := c.MaxTTL; ttl > 0 {
+		resp.AddWarning(`The Google Cloud secrets engine is using a max_ttl set ` +
+			`via the /config path. This approach is deprecated and will be removed ` +
+			`in a future release. Use "vault secrets tune" to set the max_ttl.`)
+
+		if resp.Secret.MaxTTL > ttl {
+			resp.Secret.MaxTTL = ttl
+		}
+	}
+}

--- a/plugin/path_config_rotate_root_test.go
+++ b/plugin/path_config_rotate_root_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
@@ -41,9 +40,7 @@ func TestConfigRotateRootUpdate(t *testing.T) {
 		ctx := context.Background()
 		b, storage := getTestBackend(t)
 
-		entry, err := logical.StorageEntryJSON("config", &config{
-			TTL: 5 * time.Minute,
-		})
+		entry, err := logical.StorageEntryJSON("config", &config{})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This centralizes the "ttl capping" into a central function and simultaneously deprecates said functionality to be removed in a future release. Administrators should use "vault secrets tune" to control TTLs instead of this configuration. The configuration remains parsed and used, but any paths that use the TTL now generate a warning message instructing users to migrate to "vault secrets tune" instead.

# Contributor Checklist
[x] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](https://github.com/hashicorp/vault/pull/12001)
[x] ~Add output for any tests not ran in CI to the PR description (eg, acceptance tests)~ N/A
[x] Backwards compatible 
