### PR TITLE
Backport 1.8.x: Add Support for Static Account (#107)

### DIFF
--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -35,7 +35,8 @@ type backend struct {
 
 	resources iamutil.ResourceParser
 
-	rolesetLock sync.Mutex
+	rolesetLock       sync.Mutex
+	staticAccountLock sync.Mutex
 }
 
 // Factory returns a new backend as logical.Backend.
@@ -69,12 +70,21 @@ func Backend() *backend {
 			[]*framework.Path{
 				pathConfig(b),
 				pathConfigRotateRoot(b),
+				// Roleset
 				pathRoleSet(b),
 				pathRoleSetList(b),
 				pathRoleSetRotateAccount(b),
 				pathRoleSetRotateKey(b),
-				pathSecretAccessToken(b),
-				pathSecretServiceAccountKey(b),
+				pathRoleSetSecretAccessToken(b),
+				pathRoleSetSecretServiceAccountKey(b),
+				deprecatedPathRoleSetSecretAccessToken(b),
+				deprecatedPathRoleSetSecretServiceAccountKey(b),
+				// Static Account
+				pathStaticAccount(b),
+				pathStaticAccountList(b),
+				pathStaticAccountRotateKey(b),
+				pathStaticAccountSecretAccessToken(b),
+				pathStaticAccountSecretServiceAccountKey(b),
 			},
 		),
 		Secrets: []*framework.Secret{

--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -2,11 +2,19 @@ package gcpsecrets
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-gcp-common/gcputil"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -30,4 +38,113 @@ func getTestBackend(tb testing.TB) (*backend, logical.Storage) {
 		tb.Fatal(err)
 	}
 	return b.(*backend), config.StorageView
+}
+
+// Set up/Teardown
+type testData struct {
+	B          logical.Backend
+	S          logical.Storage
+	Project    string
+	HttpClient *http.Client
+	IamAdmin   *iam.Service
+}
+
+func setupTest(t *testing.T, ttl, maxTTL string) *testData {
+	proj := util.GetTestProject(t)
+	credsJson, creds := util.GetTestCredentials(t)
+	httpC, err := gcputil.GetHttpClient(creds, iam.CloudPlatformScope)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	iamAdmin, err := iam.NewService(context.Background(), option.WithHTTPClient(httpC))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, reqStorage := getTestBackend(t)
+
+	testConfigUpdate(t, b, reqStorage, map[string]interface{}{
+		"credentials": credsJson,
+		"ttl":         ttl,
+		"max_ttl":     maxTTL,
+	})
+
+	return &testData{
+		B:          b,
+		S:          reqStorage,
+		Project:    proj,
+		HttpClient: httpC,
+		IamAdmin:   iamAdmin,
+	}
+}
+
+func cleanup(t *testing.T, td *testData, saDisplayName string, roles util.StringSet) {
+	resp, err := td.IamAdmin.Projects.ServiceAccounts.List(fmt.Sprintf("projects/%s", td.Project)).Do()
+	if err != nil {
+		t.Logf("[WARNING] Could not clean up test service accounts %s or projects/%s IAM policy bindings (did test fail?)", saDisplayName, td.Project)
+		return
+	}
+
+	memberStrs := make(util.StringSet)
+	for _, sa := range resp.Accounts {
+		if sa.DisplayName == saDisplayName {
+			memberStrs.Add("serviceAccount:" + sa.Email)
+			if _, err := td.IamAdmin.Projects.ServiceAccounts.Delete(sa.Name).Do(); err != nil {
+				if isGoogleAccountNotFoundErr(err) {
+					// Eventual consistency. We can ignore.
+					continue
+				}
+				t.Logf("[WARNING] found test service account %s that should have been deleted, did test fail? Auto-delete failed - manually clean up service account: %v", sa.Name, err)
+			}
+			t.Logf("[WARNING] found test service account %s that should have been deleted, did test fail? Manually deleted", sa.Name)
+		}
+	}
+
+	crm, err := cloudresourcemanager.New(td.HttpClient)
+	if err != nil {
+		t.Logf("[WARNING] Unable to ensure test project bindings deleted: %v", err)
+		return
+	}
+
+	p, err := crm.Projects.GetIamPolicy(td.Project, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	if err != nil {
+		t.Logf("[WARNING] Unable to ensure test project bindings deleted, could not get policy: %v", err)
+		return
+	}
+
+	var changesMade bool
+	found := make(util.StringSet)
+	for idx, b := range p.Bindings {
+		if roles.Includes(b.Role) {
+			members := make([]string, 0, len(b.Members))
+			for _, m := range b.Members {
+				if memberStrs.Includes(m) {
+					changesMade = true
+					found.Add(b.Role)
+				} else {
+					members = append(members, m)
+				}
+			}
+			p.Bindings[idx].Members = members
+		}
+	}
+
+	if !changesMade {
+		return
+	}
+
+	t.Logf("[WARNING] had to clean up some roles (%s) for test service account %s - should have been deleted (did test fail?)",
+		strings.Join(found.ToSlice(), ","), saDisplayName)
+	if _, err := crm.Projects.SetIamPolicy(td.Project, &cloudresourcemanager.SetIamPolicyRequest{Policy: p}).Do(); err != nil {
+		t.Logf("[WARNING] Auto-delete failed - manually remove bindings on project %s: %v", td.Project, err)
+	}
+}
+
+func cleanupRoleset(t *testing.T, td *testData, rsName string, roles util.StringSet) {
+	cleanup(t, td, fmt.Sprintf(serviceAccountDisplayNameTmpl, rsName), roles)
+}
+
+func cleanupStatic(t *testing.T, td *testData, saName string, roles util.StringSet) {
+	cleanup(t, td, fmt.Sprintf(staticAccountDisplayNameTmpl, saName), roles)
 }

--- a/plugin/field_data_utils.go
+++ b/plugin/field_data_utils.go
@@ -1,0 +1,108 @@
+package gcpsecrets
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
+	"github.com/hashicorp/vault/sdk/framework"
+)
+
+type inputParams struct {
+	name       string
+	secretType string
+
+	hasBindings bool
+	rawBindings string
+	bindings    ResourceBindings
+
+	project             string
+	serviceAccountEmail string
+
+	scopes []string
+}
+
+func (input *inputParams) parseOkInputSecretType(d *framework.FieldData) (warnings []string, err error) {
+	secretType := d.Get("secret_type").(string)
+	if secretType == "" && input.secretType == "" {
+		return nil, fmt.Errorf("secret_type is required")
+	}
+	if input.secretType != "" && secretType != "" && input.secretType != secretType {
+		return nil, fmt.Errorf("cannot update secret_type")
+	}
+
+	switch secretType {
+	case SecretTypeKey, SecretTypeAccessToken:
+		input.secretType = secretType
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("invalid secret_type %q", secretType)
+	}
+}
+
+// parseOkInputServiceAccountEmail checks that when creating a static acocunt, a service account
+// email is provided. A service account email can be provide while updating the static account
+// but it must be the same as the one in the static account and cannot be updated.
+func (input *inputParams) parseOkInputServiceAccountEmail(d *framework.FieldData) (warnings []string, err error) {
+	email := d.Get("service_account_email").(string)
+	if email == "" && input.serviceAccountEmail == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+	if input.serviceAccountEmail != "" && email != "" && input.serviceAccountEmail != email {
+		return nil, fmt.Errorf("cannot update email")
+	}
+
+	input.serviceAccountEmail = email
+	return nil, nil
+}
+
+func (input *inputParams) parseOkInputTokenScopes(d *framework.FieldData) (warnings []string, err error) {
+	// Parse secretType if not yet parsed
+	if input.secretType == "" {
+		warnings, err = input.parseOkInputSecretType(d)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	v, ok := d.GetOk("token_scopes")
+	if ok {
+		scopes, castOk := v.([]string)
+		if !castOk {
+			return nil, fmt.Errorf("scopes unexpected type %T, expected []string", v)
+		}
+		input.scopes = scopes
+	}
+
+	if input.secretType == SecretTypeAccessToken && len(input.scopes) == 0 {
+		return nil, fmt.Errorf("non-empty token_scopes must be provided for generating access_token secrets")
+	}
+
+	if input.secretType != SecretTypeAccessToken && ok && len(input.scopes) > 0 {
+		warnings = append(warnings, "ignoring non-empty token_scopes, secret type not access_token")
+	}
+	return
+}
+
+func (input *inputParams) parseOkInputBindings(d *framework.FieldData) (warnings []string, err error) {
+	bRaw, ok := d.GetOk("bindings")
+	if !ok {
+		input.hasBindings = false
+		return nil, nil
+	}
+
+	rawBindings, castok := bRaw.(string)
+	if !castok {
+		return nil, fmt.Errorf("bindings are not a string")
+	}
+
+	bindings, err := util.ParseBindings(bRaw.(string))
+	if err != nil {
+		return nil, errwrap.Wrapf("unable to parse bindings: {{err}}", err)
+	}
+
+	input.hasBindings = true
+	input.rawBindings = rawBindings
+	input.bindings = bindings
+	return nil, nil
+}

--- a/plugin/gcp_account_resources.go
+++ b/plugin/gcp_account_resources.go
@@ -8,11 +8,18 @@ import (
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-gcp-common/gcputil"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil"
 	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iam/v1"
+)
+
+const (
+	flagCanDeleteServiceAccount = true
+	flagMustKeepServiceAccount  = false
 )
 
 type (
@@ -44,6 +51,18 @@ func (rb ResourceBindings) asOutput() map[string][]string {
 	return out
 }
 
+func (rb ResourceBindings) sub(toRemove ResourceBindings) ResourceBindings {
+	subbed := make(ResourceBindings)
+	for r, iamRoles := range rb {
+		toRemoveIamRoles, ok := toRemove[r]
+		if ok {
+			iamRoles = iamRoles.Sub(toRemoveIamRoles)
+		}
+		subbed[r] = iamRoles
+	}
+	return subbed
+}
+
 func getStringHash(bindingsRaw string) string {
 	ssum := sha256.Sum256([]byte(bindingsRaw))
 	return base64.StdEncoding.EncodeToString(ssum[:])
@@ -61,7 +80,7 @@ func (b *backend) createNewTokenGen(ctx context.Context, req *logical.Request, p
 		parent,
 		&iam.CreateServiceAccountKeyRequest{
 			PrivateKeyType: privateKeyTypeJson,
-		}).Do()
+		}).Context(ctx).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +92,7 @@ func (b *backend) createNewTokenGen(ctx context.Context, req *logical.Request, p
 }
 
 func (b *backend) createIamBindings(ctx context.Context, req *logical.Request, saEmail string, binds ResourceBindings) error {
-	b.Logger().Debug("creating IAM bindings", "account_email", saEmail)
+	b.Logger().Debug("creating IAM bindings", "account_email", saEmail, "bindings", binds)
 	httpC, err := b.HTTPClient(req.Storage)
 	if err != nil {
 		return err
@@ -128,7 +147,147 @@ func (b *backend) createServiceAccount(ctx context.Context, req *logical.Request
 		return nil, err
 	}
 
-	return iamAdmin.Projects.ServiceAccounts.Create(fmt.Sprintf("projects/%s", project), createSaReq).Do()
+	return iamAdmin.Projects.ServiceAccounts.Create(fmt.Sprintf("projects/%s", project), createSaReq).Context(ctx).Do()
+}
+
+// tryDeleteGcpAccountResources creates WALs to clean up a service account's
+// bindings, key, and account (if removeServiceAccount is true)
+func (b *backend) tryDeleteGcpAccountResources(ctx context.Context, req *logical.Request, boundResources *gcpAccountResources, removeServiceAccount bool, walIds []string) []string {
+	if boundResources == nil {
+		b.Logger().Debug("skip deletion for nil roleset resources")
+		return nil
+	}
+
+	b.Logger().Debug("try to delete GCP account resources", "bound_resources", boundResources, "remove_service_account", removeServiceAccount)
+
+	iamAdmin, err := b.IAMAdminClient(req.Storage)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	warnings := make([]string, 0)
+	if boundResources.tokenGen != nil {
+		if err := b.deleteTokenGenKey(ctx, iamAdmin, boundResources.tokenGen); err != nil {
+			w := fmt.Sprintf("unable to delete key under service account %q (WAL entry to clean-up later has been added): %v", boundResources.accountId.ResourceName(), err)
+			warnings = append(warnings, w)
+		}
+	}
+
+	if merr := b.removeBindings(ctx, req, boundResources.accountId.EmailOrId, boundResources.bindings); merr != nil {
+		for _, err := range merr.Errors {
+			w := fmt.Sprintf("unable to delete IAM policy bindings for service account %q (WAL entry to clean-up later has been added): %v", boundResources.accountId.EmailOrId, err)
+			warnings = append(warnings, w)
+		}
+	}
+
+	if removeServiceAccount {
+		if err := b.deleteServiceAccount(ctx, iamAdmin, boundResources.accountId); err != nil {
+			w := fmt.Sprintf("unable to delete service account %q (WAL entry to clean-up later has been added): %v", boundResources.accountId.ResourceName(), err)
+			warnings = append(warnings, w)
+		}
+	}
+
+	// If resources were deleted, we don't need the WAL rollbacks we created for these resources.
+	if len(warnings) == 0 {
+		b.tryDeleteWALs(ctx, req.Storage, walIds...)
+	}
+
+	return nil
+}
+
+func (b *backend) deleteTokenGenKey(ctx context.Context, iamAdmin *iam.Service, tgen *TokenGenerator) error {
+	if tgen == nil || tgen.KeyName == "" {
+		return nil
+	}
+
+	_, err := iamAdmin.Projects.ServiceAccounts.Keys.Delete(tgen.KeyName).Context(ctx).Do()
+	if err != nil && !isGoogleAccountKeyNotFoundErr(err) {
+		return errwrap.Wrapf("unable to delete service account key: {{err}}", err)
+	}
+	return nil
+}
+
+func (b *backend) removeBindings(ctx context.Context, req *logical.Request, email string, bindings ResourceBindings) (allErr *multierror.Error) {
+	httpC, err := b.HTTPClient(req.Storage)
+	if err != nil {
+		return &multierror.Error{Errors: []error{err}}
+	}
+
+	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
+
+	for resName, roles := range bindings {
+		resource, err := b.resources.Parse(resName)
+		if err != nil {
+			allErr = multierror.Append(allErr, errwrap.Wrapf(fmt.Sprintf("unable to delete role binding for resource '%s': {{err}}", resName), err))
+			continue
+		}
+
+		p, err := resource.GetIamPolicy(ctx, apiHandle)
+		if err != nil {
+			allErr = multierror.Append(allErr, errwrap.Wrapf(fmt.Sprintf("unable to delete role binding for resource '%s': {{err}}", resName), err))
+			continue
+		}
+
+		changed, newP := p.RemoveBindings(&iamutil.PolicyDelta{
+			Email: email,
+			Roles: roles,
+		})
+		if !changed {
+			continue
+		}
+		if _, err = resource.SetIamPolicy(ctx, apiHandle, newP); err != nil {
+			allErr = multierror.Append(allErr, errwrap.Wrapf(fmt.Sprintf("unable to delete role binding for resource '%s': {{err}}", resName), err))
+			continue
+		}
+	}
+	return
+}
+
+func (b *backend) deleteServiceAccount(ctx context.Context, iamAdmin *iam.Service, account gcputil.ServiceAccountId) error {
+	if account.EmailOrId == "" {
+		return nil
+	}
+
+	_, err := iamAdmin.Projects.ServiceAccounts.Delete(account.ResourceName()).Context(ctx).Do()
+	if err != nil && !isGoogleAccountNotFoundErr(err) {
+		return errwrap.Wrapf("unable to delete service account: {{err}}", err)
+	}
+	return nil
+}
+
+func isGoogleAccountNotFoundErr(err error) bool {
+	return isGoogleApiErrorWithCodes(err, 404)
+}
+
+func isGoogleAccountKeyNotFoundErr(err error) bool {
+	return isGoogleApiErrorWithCodes(err, 403, 404)
+}
+
+func isGoogleAccountUnauthorizedErr(err error) bool {
+	return isGoogleApiErrorWithCodes(err, 403)
+}
+
+func isGoogleApiErrorWithCodes(err error, validErrCodes ...int) bool {
+	if err == nil {
+		return false
+	}
+
+	gErr, ok := err.(*googleapi.Error)
+	if !ok {
+		wrapErrV := errwrap.GetType(err, &googleapi.Error{})
+		if wrapErrV == nil {
+			return false
+		}
+		gErr = wrapErrV.(*googleapi.Error)
+	}
+
+	for _, code := range validErrCodes {
+		if gErr.Code == code {
+			return true
+		}
+	}
+
+	return false
 }
 
 func emailForServiceAccountName(project, accountName string) string {

--- a/plugin/iamutil/iam_policy.go
+++ b/plugin/iamutil/iam_policy.go
@@ -34,14 +34,14 @@ type PolicyDelta struct {
 }
 
 func (p *Policy) AddBindings(toAdd *PolicyDelta) (changed bool, updated *Policy) {
-	return p.ChangedBindings(toAdd, nil)
+	return p.ChangeBindings(toAdd, nil)
 }
 
 func (p *Policy) RemoveBindings(toRemove *PolicyDelta) (changed bool, updated *Policy) {
-	return p.ChangedBindings(nil, toRemove)
+	return p.ChangeBindings(nil, toRemove)
 }
 
-func (p *Policy) ChangedBindings(toAdd *PolicyDelta, toRemove *PolicyDelta) (changed bool, updated *Policy) {
+func (p *Policy) ChangeBindings(toAdd *PolicyDelta, toRemove *PolicyDelta) (changed bool, updated *Policy) {
 	if toAdd == nil && toRemove == nil {
 		return false, p
 	}

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -185,11 +185,11 @@ func (b *backend) pathRoleSetDelete(ctx context.Context, req *logical.Request, d
 	}
 
 	// Try to clean up resources.
-	if cleanupErr := b.tryDeleteRoleSetResources(ctx, req, resources, walIds); cleanupErr != nil {
-		b.Logger().Warn(
-			"unable to clean up unused GCP resources from deleted roleset. WALs exist to clean up but ignoring error",
-			"roleset", rsName, "errors", cleanupErr)
-		return &logical.Response{Warnings: []string{cleanupErr.Error()}}, nil
+	if warnings := b.tryDeleteRoleSetResources(ctx, req, resources, walIds); len(warnings) > 0 {
+		b.Logger().Debug(
+			"unable to delete GCP resources for deleted roleset but WALs exist to clean up, ignoring errors",
+			"roleset", rsName, "errors", warnings)
+		return &logical.Response{Warnings: warnings}, nil
 	}
 
 	b.Logger().Debug("successfully deleted roleset and GCP resources", "name", rsName)

--- a/plugin/path_role_set_secrets.go
+++ b/plugin/path_role_set_secrets.go
@@ -1,0 +1,149 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func fieldSchemaRoleSetServiceAccountKey() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"roleset": {
+			Type:        framework.TypeString,
+			Description: "Required. Name of the role set.",
+		},
+		"key_algorithm": {
+			Type:        framework.TypeString,
+			Description: fmt.Sprintf(`Private key algorithm for service account key - defaults to %s"`, keyAlgorithmRSA2k),
+			Default:     keyAlgorithmRSA2k,
+		},
+		"key_type": {
+			Type:        framework.TypeString,
+			Description: fmt.Sprintf(`Private key type for service account key - defaults to %s"`, privateKeyTypeJson),
+			Default:     privateKeyTypeJson,
+		},
+		"ttl": {
+			Type:        framework.TypeDurationSecond,
+			Description: "Lifetime of the service account key",
+		},
+	}
+}
+
+func fieldSchemaRoleSetAccessToken() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"roleset": {
+			Type:        framework.TypeString,
+			Description: "Required. Name of the role set.",
+		},
+	}
+
+}
+
+func pathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern:        fmt.Sprintf("roleset/%s/key", framework.GenericNameRegex("roleset")),
+		Fields:         fieldSchemaRoleSetServiceAccountKey(),
+		ExistenceCheck: b.pathRoleSetExistenceCheck("roleset"),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathRoleSetSecretKey},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathRoleSetSecretKey},
+		},
+		HelpSynopsis:    pathServiceAccountKeySyn,
+		HelpDescription: pathServiceAccountKeyDesc,
+	}
+}
+
+func deprecatedPathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern:        fmt.Sprintf("key/%s", framework.GenericNameRegex("roleset")),
+		Deprecated:     true,
+		Fields:         fieldSchemaRoleSetServiceAccountKey(),
+		ExistenceCheck: b.pathRoleSetExistenceCheck("roleset"),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathRoleSetSecretKey},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathRoleSetSecretKey},
+		},
+		HelpSynopsis:    pathServiceAccountKeySyn,
+		HelpDescription: pathServiceAccountKeyDesc,
+	}
+}
+
+func pathRoleSetSecretAccessToken(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern:        fmt.Sprintf("roleset/%s/token", framework.GenericNameRegex("roleset")),
+		Fields:         fieldSchemaRoleSetAccessToken(),
+		ExistenceCheck: b.pathRoleSetExistenceCheck("roleset"),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathRoleSetSecretAccessToken},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathRoleSetSecretAccessToken},
+		},
+		HelpSynopsis:    pathTokenHelpSyn,
+		HelpDescription: pathTokenHelpDesc,
+	}
+}
+
+func deprecatedPathRoleSetSecretAccessToken(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern:        fmt.Sprintf("token/%s", framework.GenericNameRegex("roleset")),
+		Deprecated:     true,
+		Fields:         fieldSchemaRoleSetAccessToken(),
+		ExistenceCheck: b.pathRoleSetExistenceCheck("roleset"),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathRoleSetSecretAccessToken},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathRoleSetSecretAccessToken},
+		},
+		HelpSynopsis:    pathTokenHelpSyn,
+		HelpDescription: pathTokenHelpDesc,
+	}
+}
+
+func (b *backend) pathRoleSetSecretKey(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	rsName := d.Get("roleset").(string)
+	keyType := d.Get("key_type").(string)
+	keyAlg := d.Get("key_algorithm").(string)
+	ttl := d.Get("ttl").(int)
+
+	rs, err := getRoleSet(rsName, ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if rs == nil {
+		return logical.ErrorResponse("role set %q does not exists", rsName), nil
+	}
+
+	if rs.SecretType != SecretTypeKey {
+		return logical.ErrorResponse("role set %q cannot generate service account keys (has secret type %s)", rsName, rs.SecretType), nil
+	}
+
+	params := secretKeyParams{
+		keyType:      keyType,
+		keyAlgorithm: keyAlg,
+		ttl:          ttl,
+		extraInternalData: map[string]interface{}{
+			"role_set":          rs.Name,
+			"role_set_bindings": rs.bindingHash(),
+		},
+	}
+
+	return b.createServiceAccountKeySecret(ctx, req.Storage, rs.AccountId, params)
+}
+
+func (b *backend) pathRoleSetSecretAccessToken(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	rsName := d.Get("roleset").(string)
+
+	rs, err := getRoleSet(rsName, ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if rs == nil {
+		return logical.ErrorResponse("role set '%s' does not exists", rsName), nil
+	}
+
+	if rs.SecretType != SecretTypeAccessToken {
+		return logical.ErrorResponse("role set '%s' cannot generate access tokens (has secret type %s)", rsName, rs.SecretType), nil
+	}
+
+	return b.secretAccessTokenResponse(ctx, req.Storage, rs.TokenGen)
+}

--- a/plugin/path_role_set_secrets_test.go
+++ b/plugin/path_role_set_secrets_test.go
@@ -1,0 +1,324 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/iam/v1"
+)
+
+func TestSecrets_getRoleSetAccessToken(t *testing.T) {
+	rsName := "test-gentoken"
+	testGetRoleSetAccessToken(t, rsName, fmt.Sprintf("roleset/%s/token", rsName))
+}
+
+func TestSecrets_getRoleSetKey(t *testing.T) {
+	rsName := "test-genkey"
+	testGetRoleSetKey(t, rsName, fmt.Sprintf("roleset/%s/key", rsName))
+}
+
+// Test deprecated path still works
+func TestSecretsDeprecated_getRoleSetAccessToken(t *testing.T) {
+	rsName := "test-gentoken"
+	testGetRoleSetAccessToken(t, rsName, fmt.Sprintf("token/%s", rsName))
+}
+
+// Test deprecated path still works
+func TestSecretsDeprecated_getRoleSetKey(t *testing.T) {
+	rsName := "test-genkey"
+	testGetRoleSetKey(t, rsName, fmt.Sprintf("key/%s", rsName))
+}
+
+func testGetRoleSetAccessToken(t *testing.T, rsName, path string) {
+	secretType := SecretTypeAccessToken
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupRoleset(t, td, rsName, testRoles)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// Create new role set
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testRoleSetCreate(t, td, rsName,
+		map[string]interface{}{
+			"secret_type":  secretType,
+			"project":      td.Project,
+			"bindings":     bindsRaw,
+			"token_scopes": []string{iam.CloudPlatformScope},
+		})
+	sa := getRoleSetAccount(t, td, rsName)
+
+	// expect error for trying to read key from token roleset
+	testGetKeyFail(t, td, fmt.Sprintf("roleset/%s/key", rsName))
+
+	token := testGetToken(t, path, td)
+
+	callC := oauth2.NewClient(
+		context.Background(),
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	)
+	checkSecretPermissions(t, td, callC)
+
+	// Cleanup: Delete role set
+	testRoleSetDelete(t, td, rsName, sa.Name)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}
+
+func testGetRoleSetKey(t *testing.T, rsName, path string) {
+	secretType := SecretTypeKey
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupRoleset(t, td, rsName, testRoles)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// Create new role set
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testRoleSetCreate(t, td, rsName,
+		map[string]interface{}{
+			"secret_type": secretType,
+			"project":     td.Project,
+			"bindings":    bindsRaw,
+		})
+	sa := getRoleSetAccount(t, td, rsName)
+
+	// expect error for trying to read token from key roleset
+	testGetTokenFail(t, td, fmt.Sprintf("roleset/%s/token", rsName))
+
+	creds, resp := testGetKey(t, path, td)
+	secret := resp.Secret
+
+	// Confirm calls with key work
+	keyHttpC := oauth2.NewClient(context.Background(), creds.TokenSource)
+	checkSecretPermissions(t, td, keyHttpC)
+
+	keyName := secret.InternalData["key_name"].(string)
+	if keyName == "" {
+		t.Fatalf("expected internal data to include key name")
+	}
+
+	_, err = td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err != nil {
+		t.Fatalf("could not get key from given internal 'key_name': %v", err)
+	}
+
+	testRenewSecretKey(t, td, secret)
+	testRevokeSecretKey(t, td, secret)
+
+	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
+		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
+	}
+	if k != nil {
+		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
+	}
+
+	// Cleanup: Delete role set
+	testRoleSetDelete(t, td, rsName, sa.Name)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}
+
+func TestSecrets_GenerateKeyConfigTTL(t *testing.T) {
+	secretType := SecretTypeKey
+	rsName := "test-genkey"
+	path := fmt.Sprintf("roleset/%s/key", rsName)
+
+	td := setupTest(t, "1h", "2h")
+	defer cleanupRoleset(t, td, rsName, testRoles)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// Create new role set
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testRoleSetCreate(t, td, rsName,
+		map[string]interface{}{
+			"secret_type": secretType,
+			"project":     td.Project,
+			"bindings":    bindsRaw,
+		})
+	sa := getRoleSetAccount(t, td, rsName)
+
+	// expect error for trying to read token from key roleset
+	testGetTokenFail(t, td, fmt.Sprintf("roleset/%s/token", rsName))
+
+	creds, resp := testGetKey(t, path, td)
+	if int(resp.Secret.LeaseTotal().Hours()) != 1 {
+		t.Fatalf("expected lease duration %d, got %d", 1, int(resp.Secret.LeaseTotal().Hours()))
+	}
+
+	// Confirm calls with key work
+	keyHttpC := oauth2.NewClient(context.Background(), creds.TokenSource)
+	checkSecretPermissions(t, td, keyHttpC)
+
+	keyName := resp.Secret.InternalData["key_name"].(string)
+	if keyName == "" {
+		t.Fatalf("expected internal data to include key name")
+	}
+
+	_, err = td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err != nil {
+		t.Fatalf("could not get key from given internal 'key_name': %v", err)
+	}
+
+	testRenewSecretKey(t, td, resp.Secret)
+	testRevokeSecretKey(t, td, resp.Secret)
+
+	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+
+	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
+		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
+	}
+	if k != nil {
+		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
+	}
+
+	// Cleanup: Delete role set
+	testRoleSetDelete(t, td, rsName, sa.Name)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}
+
+func TestSecrets_GenerateKeyTTLOverride(t *testing.T) {
+	secretType := SecretTypeKey
+	rsName := "test-genkey"
+
+	td := setupTest(t, "1h", "2h")
+	defer cleanupRoleset(t, td, rsName, testRoles)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// Create new role set
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testRoleSetCreate(t, td, rsName,
+		map[string]interface{}{
+			"secret_type": secretType,
+			"project":     td.Project,
+			"bindings":    bindsRaw,
+		})
+	sa := getRoleSetAccount(t, td, rsName)
+
+	// expect error for trying to read token from key roleset
+	testGetTokenFail(t, td, fmt.Sprintf("roleset/%s/token", rsName))
+
+	// call the POST endpoint of /gcp/roleset/:roleset:/key with TTL
+	creds, resp := testPostKey(t, td, fmt.Sprintf("roleset/%s/key", rsName), "60s")
+	if int(resp.Secret.LeaseTotal().Seconds()) != 60 {
+		t.Fatalf("expected lease duration %d, got %d", 60, int(resp.Secret.LeaseTotal().Seconds()))
+	}
+
+	// Confirm calls with key work
+	keyHttpC := oauth2.NewClient(context.Background(), creds.TokenSource)
+	checkSecretPermissions(t, td, keyHttpC)
+
+	keyName := resp.Secret.InternalData["key_name"].(string)
+	if keyName == "" {
+		t.Fatalf("expected internal data to include key name")
+	}
+
+	_, err = td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err != nil {
+		t.Fatalf("could not get key from given internal 'key_name': %v", err)
+	}
+
+	testRenewSecretKey(t, td, resp.Secret)
+	testRevokeSecretKey(t, td, resp.Secret)
+
+	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+
+	if k != nil {
+		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
+	}
+	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
+		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
+	}
+
+	// Cleanup: Delete role set
+	testRoleSetDelete(t, td, rsName, sa.Name)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}
+
+// TestSecrets_GenerateKeyMaxTTLCheck verifies the MaxTTL is set for the
+// configured backend
+func TestSecrets_GenerateKeyMaxTTLCheck(t *testing.T) {
+	secretType := SecretTypeKey
+	rsName := "test-genkey"
+
+	td := setupTest(t, "1h", "2h")
+	defer cleanupRoleset(t, td, rsName, testRoles)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// Create new role set
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testRoleSetCreate(t, td, rsName,
+		map[string]interface{}{
+			"secret_type": secretType,
+			"project":     td.Project,
+			"bindings":    bindsRaw,
+		})
+	sa := getRoleSetAccount(t, td, rsName)
+
+	// expect error for trying to read token from key roleset
+	testGetTokenFail(t, td, fmt.Sprintf("roleset/%s/token", rsName))
+
+	// call the POST endpoint of /gcp/roleset/:roleset/key with updated TTL
+	creds, resp := testPostKey(t, td, fmt.Sprintf("roleset/%s/key", rsName), "60s")
+	if int(resp.Secret.LeaseTotal().Seconds()) != 60 {
+		t.Fatalf("expected lease duration %d, got %d", 60, int(resp.Secret.LeaseTotal().Seconds()))
+	}
+
+	if int(resp.Secret.LeaseOptions.MaxTTL.Hours()) != 2 {
+		t.Fatalf("expected max lease %d, got %d", 2, int(resp.Secret.LeaseOptions.MaxTTL.Hours()))
+	}
+
+	// Confirm calls with key work
+	keyHttpC := oauth2.NewClient(context.Background(), creds.TokenSource)
+	checkSecretPermissions(t, td, keyHttpC)
+
+	keyName := resp.Secret.InternalData["key_name"].(string)
+	if keyName == "" {
+		t.Fatalf("expected internal data to include key name")
+	}
+
+	_, err = td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err != nil {
+		t.Fatalf("could not get key from given internal 'key_name': %v", err)
+	}
+
+	testRenewSecretKey(t, td, resp.Secret)
+	testRevokeSecretKey(t, td, resp.Secret)
+
+	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
+		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
+	}
+	if k != nil {
+		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
+	}
+
+	// Cleanup: Delete role set
+	testRoleSetDelete(t, td, rsName, sa.Name)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}

--- a/plugin/path_static_account.go
+++ b/plugin/path_static_account.go
@@ -1,0 +1,349 @@
+package gcpsecrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+const (
+	staticAccountStoragePrefix       = "static-account"
+	staticAccountPathPrefix          = "static-account"
+	gcpServiceAccountInferredProject = "-"
+)
+
+func pathStaticAccount(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%s/%s", staticAccountPathPrefix, framework.GenericNameRegex("name")),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Required. Name to refer to this static account in Vault. Cannot be updated.",
+			},
+			"secret_type": {
+				Type:        framework.TypeString,
+				Description: fmt.Sprintf("Type of secret generated for this account. Cannot be updated. Defaults to %q", SecretTypeAccessToken),
+				Default:     SecretTypeAccessToken,
+			},
+			"service_account_email": {
+				Type:        framework.TypeString,
+				Description: "Required. Email of the GCP service account to manage. Cannot be updated.",
+			},
+			"bindings": {
+				Type:        framework.TypeString,
+				Description: "Bindings configuration string.",
+			},
+			"token_scopes": {
+				Type:        framework.TypeCommaStringSlice,
+				Description: fmt.Sprintf(`List of OAuth scopes to assign to access tokens generated under this account. Ignored if "secret_type" is not "%q"`, SecretTypeAccessToken),
+			},
+		},
+		ExistenceCheck: b.pathStaticAccountExistenceCheck,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.DeleteOperation: &framework.PathOperation{
+				Callback: b.pathStaticAccountDelete,
+			},
+			logical.ReadOperation: &framework.PathOperation{
+				Callback: b.pathStaticAccountRead,
+			},
+			logical.CreateOperation: &framework.PathOperation{
+				Callback: b.pathStaticAccountCreate,
+			},
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathStaticAccountUpdate,
+			},
+		},
+		HelpSynopsis:    pathStaticAccountHelpSyn,
+		HelpDescription: pathStaticAccountHelpDesc,
+	}
+}
+
+func pathStaticAccountList(b *backend) *framework.Path {
+	// Paths for listing static accounts
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%ss?/?", staticAccountPathPrefix),
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ListOperation: &framework.PathOperation{
+				Callback: b.pathStaticAccountList,
+			},
+		},
+		HelpSynopsis:    pathListStaticAccountHelpSyn,
+		HelpDescription: pathListStaticAccountHelpDesc,
+	}
+}
+
+func (b *backend) pathStaticAccountExistenceCheck(ctx context.Context, req *logical.Request, d *framework.FieldData) (bool, error) {
+	nameRaw, ok := d.GetOk("name")
+	if !ok {
+		return false, errors.New("static account name is required")
+	}
+
+	acct, err := b.getStaticAccount(nameRaw.(string), ctx, req.Storage)
+	if err != nil {
+		return false, err
+	}
+
+	return acct != nil, nil
+}
+
+func (b *backend) pathStaticAccountRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	nameRaw, ok := d.GetOk("name")
+	if !ok {
+		return logical.ErrorResponse("name is required"), nil
+	}
+
+	acct, err := b.getStaticAccount(nameRaw.(string), ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if acct == nil {
+		return nil, nil
+	}
+
+	data := map[string]interface{}{
+		"service_account_project": acct.Project,
+		"service_account_email":   acct.EmailOrId,
+		"secret_type":             acct.SecretType,
+	}
+
+	if len(acct.Bindings) > 0 {
+		data["bindings"] = acct.Bindings.asOutput()
+	}
+	if acct.TokenGen != nil && acct.SecretType == SecretTypeAccessToken {
+		data["token_scopes"] = acct.TokenGen.Scopes
+	}
+
+	return &logical.Response{
+		Data: data,
+	}, nil
+}
+
+func (b *backend) pathStaticAccountDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	nameRaw, ok := d.GetOk("name")
+	if !ok {
+		return logical.ErrorResponse("name is required"), nil
+	}
+	name := nameRaw.(string)
+
+	b.staticAccountLock.Lock()
+	defer b.staticAccountLock.Unlock()
+
+	acct, err := b.getStaticAccount(name, ctx, req.Storage)
+	if err != nil {
+		return nil, errwrap.Wrapf(fmt.Sprintf("unable to get static account %q: {{err}}", name), err)
+	}
+	if acct == nil {
+		return nil, nil
+	}
+
+	resources := acct.boundResources()
+
+	// Add WALs
+	walIds, err := b.addWalsForStaticAccountResources(ctx, req, name, resources)
+	if err != nil {
+		return nil, errwrap.Wrapf(fmt.Sprintf("unable to create WALs for static account GCP resources %s: {{err}}", name), err)
+	}
+
+	// Delete static account
+	b.Logger().Debug("deleting static account from storage", "name", name)
+	if err := req.Storage.Delete(ctx, fmt.Sprintf("%s/%s", staticAccountStoragePrefix, name)); err != nil {
+		return nil, err
+	}
+
+	// Try to clean up resources.
+	if warnings := b.tryDeleteStaticAccountResources(ctx, req, resources, walIds); len(warnings) > 0 {
+		b.Logger().Debug(
+			"unable to delete GCP resources for deleted static account but WALs exist to clean up, ignoring errors",
+			"static account", name, "errors", warnings)
+		return &logical.Response{Warnings: warnings}, nil
+	}
+
+	b.Logger().Debug("finished deleting static account from storage", "name", name)
+	return nil, nil
+}
+
+func (b *backend) pathStaticAccountCreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	input, warnings, err := b.parseStaticAccountInformation(nil, d)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	if input == nil {
+		return nil, fmt.Errorf("plugin error - parse returned unexpected nil input")
+	}
+
+	b.staticAccountLock.Lock()
+	defer b.staticAccountLock.Unlock()
+
+	// Create and save static account with new resources.
+	if err := b.createStaticAccount(ctx, req, input); err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	if len(warnings) > 0 {
+		return &logical.Response{Warnings: warnings}, nil
+	}
+	return nil, nil
+}
+
+func (b *backend) pathStaticAccountUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	nameRaw, ok := d.GetOk("name")
+	if !ok {
+		return logical.ErrorResponse("name is required"), nil
+	}
+	name := nameRaw.(string)
+
+	b.staticAccountLock.Lock()
+	defer b.staticAccountLock.Unlock()
+
+	acct, err := b.getStaticAccount(name, ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if acct == nil {
+		return nil, fmt.Errorf("unable to find static account %s to update", name)
+	}
+
+	initialInput := &inputParams{
+		name:                acct.Name,
+		secretType:          acct.SecretType,
+		rawBindings:         acct.RawBindings,
+		bindings:            acct.Bindings,
+		project:             acct.Project,
+		serviceAccountEmail: acct.EmailOrId,
+	}
+	if acct.TokenGen != nil {
+		initialInput.scopes = acct.TokenGen.Scopes
+	}
+
+	updateInput, warnings, err := b.parseStaticAccountInformation(initialInput, d)
+	if err != nil {
+		return logical.ErrorResponse(err.Error()), nil
+	}
+	if updateInput == nil {
+		return nil, fmt.Errorf("plugin error - parse returned unexpected nil input")
+	}
+
+	updateWarns, err := b.updateStaticAccount(ctx, req, acct, updateInput)
+	if err != nil {
+		return logical.ErrorResponse("unable to update: %s", err), nil
+	}
+	warnings = append(warnings, updateWarns...)
+	if len(warnings) > 0 {
+		return &logical.Response{Warnings: warnings}, nil
+	}
+	return nil, nil
+}
+
+func (b *backend) pathStaticAccountList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	accounts, err := req.Storage.List(ctx, fmt.Sprintf("%s/", staticAccountStoragePrefix))
+	if err != nil {
+		return nil, err
+	}
+	return logical.ListResponse(accounts), nil
+}
+
+func (b *backend) parseStaticAccountInformation(prevValues *inputParams, d *framework.FieldData) (*inputParams, []string, error) {
+	var warnings []string
+
+	input := prevValues
+	if prevValues == nil {
+		input = &inputParams{}
+	}
+
+	nameRaw, ok := d.GetOk("name")
+	if !ok {
+		return nil, nil, fmt.Errorf("name is required")
+	}
+	input.name = nameRaw.(string)
+
+	ws, err := input.parseOkInputSecretType(d)
+	if err != nil {
+		return nil, nil, err
+	} else if len(ws) > 0 {
+		warnings = append(warnings, ws...)
+	}
+
+	ws, err = input.parseOkInputServiceAccountEmail(d)
+	if err != nil {
+		return nil, nil, err
+	} else if len(ws) > 0 {
+		warnings = append(warnings, ws...)
+	}
+
+	ws, err = input.parseOkInputTokenScopes(d)
+	if err != nil {
+		return nil, nil, err
+	} else if len(ws) > 0 {
+		warnings = append(warnings, ws...)
+	}
+
+	ws, err = input.parseOkInputBindings(d)
+	if err != nil {
+		return nil, nil, err
+	} else if len(ws) > 0 {
+		warnings = append(warnings, ws...)
+	}
+
+	return input, warnings, nil
+}
+
+const pathStaticAccountHelpSyn = `Register and manage a GCP service account to generate credentials under`
+const pathStaticAccountHelpDesc = `
+This path allows you to register a static GCP service account that you want to generate secrets against.
+This creates sets of IAM roles to specific GCP resources. Secrets (either service account keys or
+access tokens) are generated under this account. The account must exist at creation of static account creation.
+
+If bindings are specified, Vault will assign IAM permissions to the given service account. Bindings
+can be given as a HCL (or JSON) string with the following format:
+
+resource "some/gcp/resource/uri" {
+	roles = [
+		"roles/role1",
+		"roles/role2",
+		"roles/role3",
+		...
+	]
+}
+
+The given resource can have the following
+
+* Project-level self link
+	Self-link for a resource under a given project
+	(i.e. resource name starts with 'projects/...')
+	Use if you need to provide a versioned object or
+	are directly using resource.self_link.
+
+	Example (Compute instance):
+		http://www.googleapis.com/compute/v1/projects/$PROJECT/zones/$ZONE/instances/$INSTANCE_NAME
+
+* Full Resource Name
+	A scheme-less URI consisting of a DNS-compatible
+	API service name and a resource path (i.e. the
+	relative resource name). Useful if you need to
+	specify what service this resource is under
+	but just want the preferred supported API version.
+	Note that if the resource you are using is for
+	a non-preferred API with multiple service versions,
+	you MUST specify the version.
+
+	Example (IAM service account):
+		//$SERVICE.googleapis.com/projects/my-project/serviceAccounts/myserviceaccount@...
+
+* Relative Resource Name:
+	A URI path (path-noscheme) without the leading "/".
+	It identifies a resource within the API service.
+	Use if there is only one service that your
+	resource could belong to. If there are multiple
+	API versions that support the resource, we will
+	attempt to use the preferred version and ask
+	for more specific format otherwise.
+
+	Example (Pubsub subscription):
+		projects/myproject/subscriptions/mysub
+`
+
+const pathListStaticAccountHelpSyn = `List created static accounts.`
+const pathListStaticAccountHelpDesc = `List created static accounts.`

--- a/plugin/path_static_account_rotate_key.go
+++ b/plugin/path_static_account_rotate_key.go
@@ -1,0 +1,112 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathStaticAccountRotateKey(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%s/%s/rotate-key", staticAccountPathPrefix, framework.GenericNameRegex("name")),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Name of the account.",
+			},
+		},
+		ExistenceCheck: b.pathStaticAccountExistenceCheck,
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.UpdateOperation: &framework.PathOperation{
+				Callback: b.pathStaticAccountRotateKey,
+			},
+		},
+		HelpSynopsis:    pathStaticAccountRotateKeyHelpSyn,
+		HelpDescription: pathStaticAccountRotateKeyHelpDesc,
+	}
+}
+
+func (b *backend) pathStaticAccountRotateKey(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	nameRaw, ok := d.GetOk("name")
+	if !ok {
+		return logical.ErrorResponse("name is required"), nil
+	}
+	name := nameRaw.(string)
+
+	b.staticAccountLock.Lock()
+	defer b.staticAccountLock.Unlock()
+
+	acct, err := b.getStaticAccount(name, ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if acct == nil {
+		return logical.ErrorResponse("account '%s' not found", name), nil
+	}
+
+	if acct.SecretType != SecretTypeAccessToken {
+		return logical.ErrorResponse("cannot rotate key for non-access-token static account"), nil
+	}
+
+	if acct.TokenGen == nil {
+		return nil, fmt.Errorf("unexpected invalid account has no TokenGen")
+	}
+
+	scopes := acct.TokenGen.Scopes
+	oldTokenGen := acct.TokenGen
+	oldWalId, err := b.addWalRoleSetServiceAccountKey(ctx, req, acct.Name, &acct.ServiceAccountId, oldTokenGen.KeyName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add WALs for new TokenGen - since we don't have a key ID yet, give an empty key name so WAL
+	// will know to just clear keys that aren't being used. This also covers up cleaning up
+	// the old token generator, so we don't add a separate WAL for that.
+	newWalId, err := b.addWalRoleSetServiceAccountKey(ctx, req, acct.Name, &acct.ServiceAccountId, "")
+	if err != nil {
+		return nil, err
+	}
+
+	newTokenGen, err := b.createNewTokenGen(ctx, req, acct.ResourceName(), scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Edit roleset with new key and save to storage.
+	acct.TokenGen = newTokenGen
+	if err := acct.save(ctx, req.Storage); err != nil {
+		return nil, err
+	}
+
+	// Try deleting the old key.
+	iamAdmin, err := b.IAMAdminClient(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	b.tryDeleteWALs(ctx, req.Storage, newWalId)
+
+	if oldTokenGen != nil {
+		if err := b.deleteTokenGenKey(ctx, iamAdmin, oldTokenGen); err != nil {
+			return &logical.Response{
+				Warnings: []string{
+					fmt.Sprintf("saved static account with new token generator service account key but failed to delete old key (covered by WAL): %v", err),
+				},
+			}, nil
+		}
+		b.tryDeleteWALs(ctx, req.Storage, oldWalId)
+	}
+	return nil, nil
+}
+
+const pathStaticAccountRotateKeyHelpSyn = `Rotate the key used to generate access tokens for a static account`
+const pathStaticAccountRotateKeyHelpDesc = `
+This path allows you to manually rotate the service account key
+created by Vault for a static account that generates access tokens secrets.
+This path only applies to static accounts that generate access tokens. 
+It will not delete the associated service account or change bindings.
+
+Note that this will not invalidate access tokens created with the old key.
+The only way to do so is to delete the service account.
+`

--- a/plugin/path_static_account_rotate_key_test.go
+++ b/plugin/path_static_account_rotate_key_test.go
@@ -1,0 +1,87 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
+	"github.com/hashicorp/vault/sdk/logical"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/iam/v1"
+)
+
+func TestStatic_Rotate(t *testing.T) {
+	staticName := "test-static-rotate"
+	secretType := SecretTypeAccessToken
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, testRoles)
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"token_scopes":          []string{iam.CloudPlatformScope},
+			"secret_type":           secretType,
+			"bindings":              bindsRaw,
+		})
+
+	// expect error for trying to read key from token
+	testGetKeyFail(t, td, fmt.Sprintf("%s/%s/key", staticAccountPathPrefix, staticName))
+
+	// Obtain current keys
+	oldKeys := getServiceAccountKeys(t, td, sa.Name)
+
+	// Get token and check
+	token := testGetToken(t, fmt.Sprintf("%s/%s/token", staticAccountPathPrefix, staticName), td)
+	callC := oauth2.NewClient(
+		context.Background(),
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	)
+	checkSecretPermissions(t, td, callC)
+
+	// Rotate key
+	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      fmt.Sprintf("%s/%s/rotate-key", staticAccountPathPrefix, staticName),
+		Data:      map[string]interface{}{},
+		Storage:   td.S,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatal(resp.Error())
+	}
+
+	// Get new keys
+	newKeys := getServiceAccountKeys(t, td, sa.Name)
+
+	// Check that keys are actually rotated
+	if reflect.DeepEqual(oldKeys, newKeys) {
+		t.Fatal("expected keys to have been rotated, but they were not")
+	}
+
+	// Test token still works
+	token = testGetToken(t, fmt.Sprintf("%s/%s/token", staticAccountPathPrefix, staticName), td)
+	callC = oauth2.NewClient(
+		context.Background(),
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	)
+	checkSecretPermissions(t, td, callC)
+
+	// Cleanup
+	testStaticDelete(t, td, staticName)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}

--- a/plugin/path_static_account_secrets.go
+++ b/plugin/path_static_account_secrets.go
@@ -1,0 +1,106 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%s/%s/key", staticAccountPathPrefix, framework.GenericNameRegex("name")),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Required. Name of the static account.",
+			},
+			"key_algorithm": {
+				Type:        framework.TypeString,
+				Description: fmt.Sprintf(`Private key algorithm for service account key. Defaults to %s."`, keyAlgorithmRSA2k),
+				Default:     keyAlgorithmRSA2k,
+			},
+			"key_type": {
+				Type:        framework.TypeString,
+				Description: fmt.Sprintf(`Private key type for service account key. Defaults to %s."`, privateKeyTypeJson),
+				Default:     privateKeyTypeJson,
+			},
+			"ttl": {
+				Type:        framework.TypeDurationSecond,
+				Description: "Lifetime of the service account key",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathStaticAccountSecretKey},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathStaticAccountSecretKey},
+		},
+		HelpSynopsis:    pathServiceAccountKeySyn,
+		HelpDescription: pathServiceAccountKeyDesc,
+	}
+}
+
+func pathStaticAccountSecretAccessToken(b *backend) *framework.Path {
+	return &framework.Path{
+		Pattern: fmt.Sprintf("%s/%s/token", staticAccountPathPrefix, framework.GenericNameRegex("name")),
+		Fields: map[string]*framework.FieldSchema{
+			"name": {
+				Type:        framework.TypeString,
+				Description: "Required. Name of the static account.",
+			},
+		},
+		Operations: map[logical.Operation]framework.OperationHandler{
+			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathStaticAccountAccessToken},
+			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathStaticAccountAccessToken},
+		},
+		HelpSynopsis:    pathTokenHelpSyn,
+		HelpDescription: pathTokenHelpDesc,
+	}
+}
+
+func (b *backend) pathStaticAccountSecretKey(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	acctName := d.Get("name").(string)
+	keyType := d.Get("key_type").(string)
+	keyAlg := d.Get("key_algorithm").(string)
+	ttl := d.Get("ttl").(int)
+
+	acct, err := b.getStaticAccount(acctName, ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if acct == nil {
+		return logical.ErrorResponse("static account %q does not exists", acctName), nil
+	}
+	if acct.SecretType != SecretTypeKey {
+		return logical.ErrorResponse("static account %q cannot generate service account keys (has secret type %s)", acctName, acct.SecretType), nil
+	}
+
+	params := secretKeyParams{
+		keyType:      keyType,
+		keyAlgorithm: keyAlg,
+		ttl:          ttl,
+		extraInternalData: map[string]interface{}{
+			"static_account":          acct.Name,
+			"static_account_bindings": acct.bindingHash(),
+		},
+	}
+
+	return b.createServiceAccountKeySecret(ctx, req.Storage, &acct.ServiceAccountId, params)
+}
+
+func (b *backend) pathStaticAccountAccessToken(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+	acctName := d.Get("name").(string)
+
+	acct, err := b.getStaticAccount(acctName, ctx, req.Storage)
+	if err != nil {
+		return nil, err
+	}
+	if acct == nil {
+		return logical.ErrorResponse("static account %q does not exists", acctName), nil
+	}
+	if acct.SecretType != SecretTypeAccessToken {
+		return logical.ErrorResponse("static account %q cannot generate access tokens (has secret type %s)", acctName, acct.SecretType), nil
+	}
+
+	return b.secretAccessTokenResponse(ctx, req.Storage, acct.TokenGen)
+}

--- a/plugin/path_static_account_secrets_test.go
+++ b/plugin/path_static_account_secrets_test.go
@@ -1,0 +1,144 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
+	"github.com/hashicorp/vault/sdk/logical"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/iam/v1"
+)
+
+func TestStaticSecrets_GetAccessToken(t *testing.T) {
+	staticName := "test-static-token"
+	testGetStaticAccessToken(t, staticName)
+}
+
+func TestStaticSecrets_GetKey(t *testing.T) {
+	staticName := "test-static-key"
+	testGetStaticKey(t, staticName, 0)
+}
+
+func TestStaticSecrets_GetKeyTTLOverride(t *testing.T) {
+	staticName := "test-static-key-ttl"
+	testGetStaticKey(t, staticName, 1200)
+}
+
+func testGetStaticAccessToken(t *testing.T, staticName string) {
+	secretType := SecretTypeAccessToken
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, testRoles)
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"token_scopes":          []string{iam.CloudPlatformScope},
+			"secret_type":           secretType,
+			"bindings":              bindsRaw,
+		})
+
+	// expect error for trying to read key from token
+	testGetKeyFail(t, td, fmt.Sprintf("%s/%s/key", staticAccountPathPrefix, staticName))
+
+	token := testGetToken(t, fmt.Sprintf("%s/%s/token", staticAccountPathPrefix, staticName), td)
+
+	callC := oauth2.NewClient(
+		context.Background(),
+		oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}),
+	)
+	checkSecretPermissions(t, td, callC)
+
+	// Cleanup
+	testStaticDelete(t, td, staticName)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}
+
+func testGetStaticKey(t *testing.T, staticName string, ttl uint64) {
+	secretType := SecretTypeKey
+
+	td := setupTest(t, "60s", "2h")
+	defer cleanupStatic(t, td, staticName, testRoles)
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"secret_type":           secretType,
+			"bindings":              bindsRaw,
+		})
+
+	// expect error for trying to read token
+	testGetTokenFail(t, td, fmt.Sprintf("%s/%s/token", staticAccountPathPrefix, staticName))
+
+	var creds *google.Credentials
+	var resp *logical.Response
+	if ttl == 0 {
+		creds, resp = testGetKey(t, fmt.Sprintf("%s/%s/key", staticAccountPathPrefix, staticName), td)
+		if uint(resp.Secret.LeaseTotal().Seconds()) != 60 {
+			t.Fatalf("expected lease duration %d, got %d", 60, int(resp.Secret.LeaseTotal().Seconds()))
+		}
+	} else {
+		// call the POST endpoint of /gcp/key/:roleset:/key with TTL
+		creds, resp = testPostKey(t, td, fmt.Sprintf("%s/%s/key", staticAccountPathPrefix, staticName), fmt.Sprintf("%ds", ttl))
+		if uint64(resp.Secret.LeaseTotal().Seconds()) != ttl {
+			t.Fatalf("expected lease duration %d, got %d", ttl, int(resp.Secret.LeaseTotal().Seconds()))
+		}
+	}
+
+	if int(resp.Secret.LeaseOptions.MaxTTL.Hours()) != 2 {
+		t.Fatalf("expected max lease %d, got %d", 2, int(resp.Secret.LeaseOptions.MaxTTL.Hours()))
+	}
+
+	secret := resp.Secret
+	// Confirm calls with key work
+	keyHttpC := oauth2.NewClient(context.Background(), creds.TokenSource)
+	checkSecretPermissions(t, td, keyHttpC)
+
+	keyName := secret.InternalData["key_name"].(string)
+	if keyName == "" {
+		t.Fatalf("expected internal data to include key name")
+	}
+
+	_, err = td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err != nil {
+		t.Fatalf("could not get key from given internal 'key_name': %v", err)
+	}
+
+	testRenewSecretKey(t, td, secret)
+	testRevokeSecretKey(t, td, secret)
+
+	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
+		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
+	}
+	if k != nil {
+		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
+	}
+
+	// Cleanup
+	testStaticDelete(t, td, staticName)
+	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}

--- a/plugin/path_static_account_test.go
+++ b/plugin/path_static_account_test.go
@@ -1,0 +1,508 @@
+package gcpsecrets
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
+	"github.com/hashicorp/vault/sdk/logical"
+	"google.golang.org/api/iam/v1"
+)
+
+const staticAccountDisplayNameTmpl = "Test Static Account for Vault secrets backend %s"
+
+func TestPathStatic_Basic(t *testing.T) {
+	staticName := "test-static-basic"
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, util.StringSet{})
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	// Obtain current keys
+	oldKeys := getServiceAccountKeys(t, td, sa.Name)
+
+	// 1. Read should return nothing
+	respData := testStaticRead(t, td, staticName)
+	if respData != nil {
+		t.Fatalf("expected static account to not exist initially")
+	}
+
+	// 2. Create new static account
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"token_scopes":          []string{iam.CloudPlatformScope},
+		})
+
+	// Get new keys
+	newKeys := getServiceAccountKeys(t, td, sa.Name)
+
+	if len(newKeys)-len(oldKeys) != 1 {
+		t.Fatal("expected one new key to be created for the service account but that was not the case")
+	}
+
+	// 3. Read static account
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to have been created")
+	}
+
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeAccessToken, // default
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                nil,
+	})
+	// Test static account is listed
+	testStaticList(t, td, staticName)
+
+	// 4. Delete static account
+	testStaticDelete(t, td, staticName)
+	finalKeys := getServiceAccountKeys(t, td, sa.Name)
+	if len(finalKeys)-len(newKeys) != -1 {
+		t.Fatal("expected one fewer service account key upon deletion but that was not the case")
+	}
+}
+
+func TestPathStatic_Key(t *testing.T) {
+	staticName := "test-static-key"
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, util.StringSet{})
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	// 1. Read should return nothing
+	respData := testStaticRead(t, td, staticName)
+	if respData != nil {
+		t.Fatalf("expected static account to not exist initially")
+	}
+
+	// 2. Create new static account
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"secret_type":           SecretTypeKey,
+			"service_account_email": sa.Email,
+			"token_scopes":          []string{iam.CloudPlatformScope},
+		})
+
+	// 3. Read static account
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to have been created")
+	}
+
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeKey,
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                nil,
+	})
+	// Test static account is listed
+	testStaticList(t, td, staticName)
+
+	// 4. Delete static account
+	testStaticDelete(t, td, staticName)
+}
+
+// Tests that some fields cannot be updated
+func TestPathStatic_UpdateDisallowed(t *testing.T) {
+	staticName := "test-static-update-fail"
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, util.StringSet{})
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	saNew := createStaticAccount(t, td, staticName+"-new")
+	defer cleanupStatic(t, td, staticName+"-new", util.StringSet{})
+	defer deleteStaticAccount(t, td, saNew)
+
+	// 1. Read should return nothing
+	respData := testStaticRead(t, td, staticName)
+	if respData != nil {
+		t.Fatalf("expected static account to not exist initially")
+	}
+
+	// 2. Create new static account
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"secret_type":           SecretTypeKey,
+		})
+
+	// 3. Read static account
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to have been created")
+	}
+
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeKey,
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                nil,
+	})
+
+	// 4. Verify theses updates don't work:
+	errCases := []map[string]interface{}{
+		{
+			// Email cannot be changed
+			"service_account_email": saNew.Email,
+		},
+		{
+			// Cannot change secret type
+			"secret_type": SecretTypeAccessToken,
+		},
+	}
+	for _, d := range errCases {
+		resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+			Operation: logical.UpdateOperation,
+			Path:      fmt.Sprintf("%s/%s", staticAccountPathPrefix, staticName),
+			Data:      d,
+			Storage:   td.S,
+		})
+		if err == nil && (resp != nil && !resp.IsError()) {
+			t.Fatalf("expected update to fail; data: %v", d)
+		}
+	}
+
+	// 5. Delete static account
+	testStaticDelete(t, td, staticName)
+}
+
+func TestPathStatic_WithBindings(t *testing.T) {
+	staticName := "test-static-binding"
+	roles := util.StringSet{
+		"roles/viewer": struct{}{},
+	}
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, roles)
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// 1. Read should return nothing
+	respData := testStaticRead(t, td, staticName)
+	if respData != nil {
+		t.Fatalf("expected static account to not exist initially")
+	}
+
+	// 2. Create new static account
+	expectedBinds := ResourceBindings{projRes: roles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"bindings":              bindsRaw,
+			"token_scopes":          []string{iam.CloudPlatformScope},
+		})
+
+	// 3. Read static account
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to have been created")
+	}
+
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeAccessToken, // default
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                expectedBinds,
+	})
+	// Test static account is listed
+	testStaticList(t, td, staticName)
+
+	// Verify service account has given role on project
+	verifyProjectBinding(t, td, sa.Email, roles)
+
+	// 4. Delete static account
+	testStaticDelete(t, td, staticName)
+	verifyProjectBindingsRemoved(t, td, sa.Email, roles)
+}
+
+func TestPathStatic_UpdateBinding(t *testing.T) {
+	staticName := "test-static-up-binding"
+
+	initRoles := util.StringSet{
+		"roles/viewer": struct{}{},
+	}
+	updatedRoles := util.StringSet{
+		"roles/browser":         struct{}{},
+		"roles/cloudsql.client": struct{}{},
+	}
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupStatic(t, td, staticName, initRoles.Union(updatedRoles))
+
+	sa := createStaticAccount(t, td, staticName)
+	defer deleteStaticAccount(t, td, sa)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, td.Project)
+
+	// 1. Read should return nothing
+	respData := testStaticRead(t, td, staticName)
+	if respData != nil {
+		t.Fatalf("expected static account to not exist initially")
+	}
+
+	// 2. Create new static account
+	testStaticCreate(t, td, staticName,
+		map[string]interface{}{
+			"service_account_email": sa.Email,
+			"token_scopes":          []string{iam.CloudPlatformScope},
+		})
+
+	// 3. Read static account
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to have been created")
+	}
+
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeAccessToken, // default
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                nil,
+	})
+
+	// Verify service account has no role on project
+	verifyProjectBinding(t, td, sa.Email, util.StringSet{})
+
+	// 4. Add Binding
+	expectedBinds := ResourceBindings{projRes: initRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testStaticUpdate(t, td, staticName, map[string]interface{}{
+		"service_account_email": sa.Email,
+		"token_scopes":          []string{iam.CloudPlatformScope},
+		"bindings":              bindsRaw,
+	})
+
+	// 5. Check Binding is added
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to still exist")
+	}
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeAccessToken, // default
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                expectedBinds,
+	})
+	// Verify service account has given role on project
+	verifyProjectBinding(t, td, sa.Email, initRoles)
+
+	// 6. Modify Binding
+	expectedBinds = ResourceBindings{projRes: updatedRoles}
+	bindsRaw, err = util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	testStaticUpdate(t, td, staticName, map[string]interface{}{
+		"service_account_email": sa.Email,
+		"token_scopes":          []string{iam.CloudPlatformScope},
+		"bindings":              bindsRaw,
+	})
+
+	// 7. Check Binding is modified
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to still exist")
+	}
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeAccessToken, // default
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                expectedBinds,
+	})
+	// Verify service account has given role on project
+	verifyProjectBinding(t, td, sa.Email, updatedRoles)
+	verifyProjectBindingsRemoved(t, td, sa.Email, initRoles)
+
+	// 8. Remove Binding
+	testStaticUpdate(t, td, staticName, map[string]interface{}{
+		"service_account_email": sa.Email,
+		"token_scopes":          []string{iam.CloudPlatformScope},
+		"bindings":              "",
+	})
+
+	// 9. Check Binding is removed
+	respData = testStaticRead(t, td, staticName)
+	if respData == nil {
+		t.Fatalf("expected static account to still exist")
+	}
+	verifyReadData(t, respData, map[string]interface{}{
+		"secret_type":             SecretTypeAccessToken, // default
+		"service_account_email":   sa.Email,
+		"service_account_project": sa.ProjectId,
+		"bindings":                nil,
+	})
+	verifyProjectBindingsRemoved(t, td, sa.Email, updatedRoles)
+
+	// 10. Delete static account
+	testStaticDelete(t, td, staticName)
+}
+
+func createStaticAccount(t *testing.T, td *testData, staticName string) *iam.ServiceAccount {
+	intSuffix := fmt.Sprintf("%d", time.Now().Unix())
+	fullName := fmt.Sprintf("%s-%s", staticName, intSuffix)
+	if len(fullName) > 30 {
+		fullName = fullName[0:30]
+	}
+
+	createSaReq := &iam.CreateServiceAccountRequest{
+		AccountId: fullName,
+		ServiceAccount: &iam.ServiceAccount{
+			DisplayName: fmt.Sprintf(staticAccountDisplayNameTmpl, staticName),
+		},
+	}
+
+	sa, err := td.IamAdmin.Projects.ServiceAccounts.Create(fmt.Sprintf("projects/%s", td.Project), createSaReq).Do()
+	if err != nil {
+		t.Fatalf("could not create static service account %q", err)
+	}
+
+	return sa
+}
+
+func deleteStaticAccount(t *testing.T, td *testData, sa *iam.ServiceAccount) {
+	_, err := td.IamAdmin.Projects.ServiceAccounts.Delete(sa.Name).Do()
+
+	if err != nil {
+		t.Logf("[WARNING] Could not clean up test static service account %s", sa.Name)
+	}
+}
+
+func testStaticRead(t *testing.T, td *testData, staticName string) map[string]interface{} {
+	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ReadOperation,
+		Path:      fmt.Sprintf("%s/%s", staticAccountStoragePrefix, staticName),
+		Storage:   td.S,
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.IsError() {
+		t.Fatal(resp.Error())
+	}
+	if resp == nil {
+		return nil
+	}
+
+	return resp.Data
+}
+
+func testStaticCreate(t *testing.T, td *testData, staticName string, d map[string]interface{}) {
+	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      fmt.Sprintf("%s/%s", staticAccountPathPrefix, staticName),
+		Data:      d,
+		Storage:   td.S,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatal(resp.Error())
+	}
+}
+
+func testStaticUpdate(t *testing.T, td *testData, staticName string, d map[string]interface{}) {
+	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.UpdateOperation,
+		Path:      fmt.Sprintf("%s/%s", staticAccountPathPrefix, staticName),
+		Data:      d,
+		Storage:   td.S,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != nil && resp.IsError() {
+		t.Fatal(resp.Error())
+	}
+}
+
+func testStaticDelete(t *testing.T, td *testData, staticName string) {
+	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.DeleteOperation,
+		Path:      fmt.Sprintf("%s/%s", staticAccountPathPrefix, staticName),
+		Storage:   td.S,
+	})
+
+	if err != nil {
+		t.Fatalf("unable to delete static account: %v", err)
+	} else if resp != nil {
+		if len(resp.Warnings) > 0 {
+			t.Logf("warnings returned from static account delete. Warnings:\n %s\n", strings.Join(resp.Warnings, ",\n"))
+		}
+		if resp.IsError() {
+			t.Fatalf("unable to delete static account: %v", resp.Error())
+		}
+	}
+}
+
+func testStaticList(t *testing.T, td *testData, staticName string) {
+	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.ListOperation,
+		Path:      staticAccountPathPrefix,
+		Storage:   td.S,
+	})
+
+	if err != nil {
+		t.Fatalf("unable to list static accounts: %v", err)
+	} else if resp != nil {
+		if len(resp.Warnings) > 0 {
+			t.Logf("warnings returned from static account list. Warnings:\n %s\n", strings.Join(resp.Warnings, ",\n"))
+		}
+		if resp.IsError() {
+			t.Fatalf("unable to list static accounts: %v", resp.Error())
+		}
+		keys, ok := resp.Data["keys"].([]string)
+		if !ok {
+			t.Fatalf("expected response to contain data map with key 'key' of type []string keys")
+		}
+		found := false
+		for _, s := range keys {
+			if s == staticName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected static accounts listing to contain static account but did not")
+		}
+	}
+}
+
+// Return a list of key IDs for a service account
+func getServiceAccountKeys(t *testing.T, td *testData, saName string) []string {
+	keysRaw, err := td.IamAdmin.Projects.ServiceAccounts.Keys.List(saName).Do()
+	if err != nil {
+		t.Fatalf("error listing service account keys: %v", err)
+	}
+	var keys []string
+	for _, key := range keysRaw.Keys {
+		keys = append(keys, key.Name)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -4,23 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-gcp-common/gcputil"
-	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/iamutil"
 	"github.com/hashicorp/vault-plugin-secrets-gcp/plugin/util"
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/helper/useragent"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/mitchellh/mapstructure"
-	"google.golang.org/api/googleapi"
-	"google.golang.org/api/iam/v1"
 )
 
 const (
-	walTypeAccount    = "account"
-	walTypeAccountKey = "account_key"
-	walTypeIamPolicy  = "iam_policy"
+	walTypeAccount       = "account"
+	walTypeAccountKey    = "account_key"
+	walTypeIamPolicy     = "iam_policy"
+	walTypeIamPolicyDiff = "iam_policy_diff"
 )
 
 func (b *backend) walRollback(ctx context.Context, req *logical.Request, kind string, data interface{}) error {
@@ -31,6 +28,8 @@ func (b *backend) walRollback(ctx context.Context, req *logical.Request, kind st
 		return b.serviceAccountKeyRollback(ctx, req, data)
 	case walTypeIamPolicy:
 		return b.serviceAccountPolicyRollback(ctx, req, data)
+	case walTypeIamPolicyDiff:
+		return b.serviceAccountPolicyDiffRollback(ctx, req, data)
 	default:
 		return fmt.Errorf("unknown type to rollback")
 	}
@@ -43,6 +42,7 @@ type walAccount struct {
 
 type walAccountKey struct {
 	RoleSet            string
+	StaticAccount      string
 	ServiceAccountName string
 	KeyName            string
 }
@@ -54,6 +54,14 @@ type walIamPolicy struct {
 	Roles     []string
 }
 
+type walIamPolicyStaticAccount struct {
+	StaticAccount string
+	AccountId     gcputil.ServiceAccountId
+	Resource      string
+	RolesAdded    []string
+	RolesRemoved  []string
+}
+
 func (b *backend) serviceAccountRollback(ctx context.Context, req *logical.Request, data interface{}) error {
 	b.rolesetLock.Lock()
 	defer b.rolesetLock.Unlock()
@@ -63,13 +71,13 @@ func (b *backend) serviceAccountRollback(ctx context.Context, req *logical.Reque
 		return err
 	}
 
-	// If account is still being used, WAL entry was not
-	// deleted properly after a successful operation.
-	// Remove WAL entry.
 	rs, err := getRoleSet(entry.RoleSet, ctx, req.Storage)
 	if err != nil {
 		return err
 	}
+
+	// If account is still being used, WAL entry was not deleted properly after a successful operation.
+	// Remove WAL entry.
 	if rs != nil && entry.Id.ResourceName() == rs.AccountId.ResourceName() {
 		// Still being used - don't delete this service account.
 		return nil
@@ -93,26 +101,46 @@ func (b *backend) serviceAccountKeyRollback(ctx context.Context, req *logical.Re
 		return err
 	}
 
-	b.Logger().Debug("checking roleset listed in WAL is access_token roleset")
-
+	b.Logger().Debug("checking parent listed in WAL generates access_token secret")
 	var keyInUse string
 
-	// Get roleset for entry
-	rs, err := getRoleSet(entry.RoleSet, ctx, req.Storage)
-	if err != nil {
-		return err
-	}
-
-	// If roleset is not nil, get key in use.
-	if rs != nil {
-		if rs.SecretType != SecretTypeAccessToken {
-			// Don't clean keys if roleset doesn't create access_tokens (i.e. creates keys).
-			return nil
+	switch {
+	case entry.RoleSet != "":
+		rs, err := getRoleSet(entry.RoleSet, ctx, req.Storage)
+		if err != nil {
+			return err
 		}
 
-		if rs.TokenGen != nil {
-			keyInUse = rs.TokenGen.KeyName
+		// If roleset is not nil, get key in use.
+		if rs != nil {
+			if rs.SecretType != SecretTypeAccessToken {
+				// Remove WAL entry - we don't clean keys if roleset generates key secrets.
+				return nil
+			}
+
+			if rs.TokenGen != nil {
+				keyInUse = rs.TokenGen.KeyName
+			}
 		}
+	case entry.StaticAccount != "":
+		sa, err := b.getStaticAccount(entry.StaticAccount, ctx, req.Storage)
+		if err != nil {
+			return err
+		}
+
+		// If roleset is not nil, get key in use.
+		if sa != nil {
+			if sa.SecretType != SecretTypeAccessToken {
+				// Remove WAL entry - we don't clean keys if roleset generates key secrets.
+				return nil
+			}
+			if sa.TokenGen != nil {
+				keyInUse = sa.TokenGen.KeyName
+			}
+		}
+	default:
+		b.Logger().Error("removing invalid walAccountKey with empty RoleSet and empty StaticAccount, may need manual cleanup: %v", entry)
+		return nil
 	}
 
 	iamC, err := b.IAMAdminClient(req.Storage)
@@ -167,19 +195,21 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 		return err
 	}
 
+	var rolesInUse util.StringSet
+
 	// Try to verify service account not being used by roleset
 	rs, err := getRoleSet(entry.RoleSet, ctx, req.Storage)
 	if err != nil {
 		return err
 	}
+	if rs.AccountId != nil && rs.AccountId.ResourceName() == entry.AccountId.ResourceName() {
+		rolesInUse = rs.Bindings[entry.Resource]
+	}
 
 	// Take out any bindings still being used by this role set from roles being removed.
 	rolesToRemove := util.ToSet(entry.Roles)
-	if rs != nil && rs.AccountId.ResourceName() == entry.AccountId.ResourceName() {
-		currRoles, ok := rs.Bindings[entry.Resource]
-		if ok {
-			rolesToRemove = rolesToRemove.Sub(currRoles)
-		}
+	if len(rolesInUse) > 0 {
+		rolesToRemove = rolesToRemove.Sub(rolesInUse)
 	}
 
 	r, err := b.resources.Parse(entry.Resource)
@@ -193,10 +223,6 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 	}
 
 	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
-	if err != nil {
-		return err
-	}
-
 	p, err := r.GetIamPolicy(ctx, apiHandle)
 	if err != nil {
 		if isGoogleAccountNotFoundErr(err) || isGoogleAccountUnauthorizedErr(err) {
@@ -210,7 +236,6 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 			Email: entry.AccountId.EmailOrId,
 			Roles: rolesToRemove,
 		})
-
 	if !changed {
 		return nil
 	}
@@ -219,59 +244,69 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 	return err
 }
 
-func (b *backend) deleteServiceAccount(ctx context.Context, iamAdmin *iam.Service, account gcputil.ServiceAccountId) error {
-	if account.EmailOrId == "" {
-		return nil
+func (b *backend) serviceAccountPolicyDiffRollback(ctx context.Context, req *logical.Request, data interface{}) error {
+	b.staticAccountLock.Lock()
+	defer b.staticAccountLock.Unlock()
+
+	var entry walIamPolicyStaticAccount
+	if err := mapstructure.Decode(data, &entry); err != nil {
+		return err
 	}
 
-	_, err := iamAdmin.Projects.ServiceAccounts.Delete(account.ResourceName()).Do()
+	var rolesInUse util.StringSet
+
+	// Try to verify service account not being used by roleset
+	sa, err := b.getStaticAccount(entry.StaticAccount, ctx, req.Storage)
 	if err != nil {
-		if !isGoogleAccountNotFoundErr(err) && !isGoogleAccountUnauthorizedErr(err) {
-			return errwrap.Wrapf("unable to delete service account: {{err}}", err)
-		}
+		return err
 	}
-	return nil
-}
+	if sa == nil {
+		b.Logger().Warn("static account %s not found, dropping WAL entry", entry.StaticAccount)
+		return nil
+	}
+	if sa.ResourceName() == entry.AccountId.ResourceName() {
+		rolesInUse = sa.Bindings[entry.Resource]
+	}
 
-func (b *backend) deleteTokenGenKey(ctx context.Context, iamAdmin *iam.Service, tgen *TokenGenerator) error {
-	if tgen == nil || tgen.KeyName == "" {
+	// We added roles that are not actually in use
+	addedRolesToRemove := util.ToSet(entry.RolesAdded).Sub(rolesInUse)
+
+	// We removed roles that are still saved
+	removedRolesToAdd := util.ToSet(entry.RolesRemoved).Intersection(rolesInUse)
+
+	r, err := b.resources.Parse(entry.Resource)
+	if err != nil {
+		return err
+	}
+
+	httpC, err := b.HTTPClient(req.Storage)
+	if err != nil {
+		return err
+	}
+
+	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
+	p, err := r.GetIamPolicy(ctx, apiHandle)
+	if err != nil {
+		return err
+	}
+
+	changed, newP := p.ChangeBindings(
+		// toAdd
+		&iamutil.PolicyDelta{
+			Email: entry.AccountId.EmailOrId,
+			Roles: removedRolesToAdd,
+		},
+		// toRemove
+		&iamutil.PolicyDelta{
+			Email: entry.AccountId.EmailOrId,
+			Roles: addedRolesToRemove,
+		})
+	if !changed {
 		return nil
 	}
 
-	_, err := iamAdmin.Projects.ServiceAccounts.Keys.Delete(tgen.KeyName).Do()
-	if err != nil && !isGoogleAccountKeyNotFoundErr(err) {
-		return errwrap.Wrapf("unable to delete service account key: {{err}}", err)
-	}
-	return nil
-}
-
-func (b *backend) removeBindings(ctx context.Context, apiHandle *iamutil.ApiHandle, email string, bindings ResourceBindings) (allErr *multierror.Error) {
-	for resName, roles := range bindings {
-		resource, err := b.resources.Parse(resName)
-		if err != nil {
-			allErr = multierror.Append(allErr, errwrap.Wrapf(fmt.Sprintf("unable to delete role binding for resource '%s': {{err}}", resName), err))
-			continue
-		}
-
-		p, err := resource.GetIamPolicy(ctx, apiHandle)
-		if err != nil {
-			allErr = multierror.Append(allErr, errwrap.Wrapf(fmt.Sprintf("unable to delete role binding for resource '%s': {{err}}", resName), err))
-			continue
-		}
-
-		changed, newP := p.RemoveBindings(&iamutil.PolicyDelta{
-			Email: email,
-			Roles: roles,
-		})
-		if !changed {
-			continue
-		}
-		if _, err = resource.SetIamPolicy(ctx, apiHandle, newP); err != nil {
-			allErr = multierror.Append(allErr, errwrap.Wrapf(fmt.Sprintf("unable to delete role binding for resource '%s': {{err}}", resName), err))
-			continue
-		}
-	}
-	return
+	_, err = r.SetIamPolicy(ctx, apiHandle, newP)
+	return err
 }
 
 // This tries to clean up WALs that are no longer needed.
@@ -285,36 +320,4 @@ func (b *backend) tryDeleteWALs(ctx context.Context, s logical.Storage, walIds .
 			b.Logger().Error("unable to delete unneeded WAL %s, ignoring error since WAL will no-op: %v", walId, err)
 		}
 	}
-}
-
-func isGoogleAccountNotFoundErr(err error) bool {
-	return isGoogleApiErrorWithCodes(err, 404)
-}
-
-func isGoogleAccountUnauthorizedErr(err error) bool {
-	return isGoogleApiErrorWithCodes(err, 403)
-}
-
-func isGoogleAccountKeyNotFoundErr(err error) bool {
-	return isGoogleApiErrorWithCodes(err, 403, 404)
-}
-
-func isGoogleApiErrorWithCodes(err error, validErrCodes ...int) bool {
-	if err == nil {
-		return false
-	}
-	ok := errwrap.ContainsType(err, new(googleapi.Error))
-	if !ok {
-		return false
-	}
-
-	gErr := errwrap.GetType(err, new(googleapi.Error)).(*googleapi.Error)
-
-	for _, code := range validErrCodes {
-		if gErr.Code == code {
-			return true
-		}
-	}
-
-	return false
 }

--- a/plugin/secrets_access_token.go
+++ b/plugin/secrets_access_token.go
@@ -3,7 +3,6 @@ package gcpsecrets
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -13,49 +12,12 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-func pathSecretAccessToken(b *backend) *framework.Path {
-	return &framework.Path{
-		Pattern: fmt.Sprintf("token/%s", framework.GenericNameRegex("roleset")),
-		Fields: map[string]*framework.FieldSchema{
-			"roleset": {
-				Type:        framework.TypeString,
-				Description: "Required. Name of the role set.",
-			},
-		},
-		ExistenceCheck: b.pathRoleSetExistenceCheck("roleset"),
-		Operations: map[logical.Operation]framework.OperationHandler{
-			logical.ReadOperation:   &framework.PathOperation{Callback: b.pathAccessToken},
-			logical.UpdateOperation: &framework.PathOperation{Callback: b.pathAccessToken},
-		},
-		HelpSynopsis:    pathTokenHelpSyn,
-		HelpDescription: pathTokenHelpDesc,
-	}
-}
-
-func (b *backend) pathAccessToken(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	rsName := d.Get("roleset").(string)
-
-	rs, err := getRoleSet(rsName, ctx, req.Storage)
-	if err != nil {
-		return nil, err
-	}
-	if rs == nil {
-		return logical.ErrorResponse("role set '%s' does not exist", rsName), nil
+func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Storage, tokenGen *TokenGenerator) (*logical.Response, error) {
+	if tokenGen == nil || tokenGen.KeyName == "" {
+		return logical.ErrorResponse("invalid token generator has no service account key"), nil
 	}
 
-	if rs.SecretType != SecretTypeAccessToken {
-		return logical.ErrorResponse("role set '%s' cannot generate access tokens (has secret type %s)", rsName, rs.SecretType), nil
-	}
-
-	return b.secretAccessTokenResponse(ctx, req.Storage, rs)
-}
-
-func (b *backend) secretAccessTokenResponse(ctx context.Context, s logical.Storage, rs *RoleSet) (*logical.Response, error) {
-	if rs.TokenGen == nil || rs.TokenGen.KeyName == "" {
-		return logical.ErrorResponse("invalid role set has no service account key, must be updated (path roleset/%s/rotate-key) before generating new secrets", rs.Name), nil
-	}
-
-	token, err := rs.TokenGen.getAccessToken(ctx)
+	token, err := tokenGen.getAccessToken(ctx)
 	if err != nil {
 		return logical.ErrorResponse("unable to generate token - make sure your roleset service account and key are still valid: %v", err), nil
 	}
@@ -94,24 +56,21 @@ engine and will be cleaned up now. Note that there is the chance that this acces
 will still be valid up to one hour.
 `
 
-const pathTokenHelpSyn = `Generate an OAuth2 access token under a specific role set.`
+const pathTokenHelpSyn = `Generate an OAuth2 access token secret.`
 const pathTokenHelpDesc = `
 This path will generate a new OAuth2 access token for accessing GCP APIs.
-A role set, binding IAM roles to specific GCP resources, will be specified
-by name - for example, if this backend is mounted at "gcp",
-then "gcp/token/deploy" would generate tokens for the "deploy" role set.
 
-On the backend, each roleset is associated with a service account.
-The token will be associated with this service account. Tokens have a
-short-term lease (1-hour) associated with them but cannot be renewed.
+Either specify "roleset/my-roleset" or "static/my-account" to generate a key corresponding
+to a roleset or static account respectively.
 
 Please see backend documentation for more information:
 https://www.vaultproject.io/docs/secrets/gcp/index.html
 `
 
-// EVERYTHING USING THIS SECRET TYPE IS CURRENTLY DEPRECATED.
-// We keep it to allow for clean up of access_token secrets/leases that may have be left over
-// by older versions of Vault.
+// THIS SECRET TYPE IS DEPRECATED - future secret requests returns a response with no framework.Secret
+// We are keeping them as part of the created framework.Secret
+// to allow for clean up of access_token secrets and leases
+// from older versions of Vault.
 const SecretTypeAccessToken = "access_token"
 
 func secretAccessToken(b *backend) *framework.Secret {

--- a/plugin/static_account.go
+++ b/plugin/static_account.go
@@ -1,0 +1,346 @@
+package gcpsecrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-gcp-common/gcputil"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/strutil"
+	"github.com/hashicorp/vault/sdk/logical"
+)
+
+func (b *backend) getStaticAccount(name string, ctx context.Context, s logical.Storage) (*StaticAccount, error) {
+	b.Logger().Debug("getting static account from storage", "static_account_name", name)
+	entry, err := s.Get(ctx, fmt.Sprintf("%s/%s", staticAccountStoragePrefix, name))
+	if err != nil {
+		return nil, err
+	}
+	if entry == nil {
+		return nil, nil
+	}
+
+	a := &StaticAccount{}
+	if err := entry.DecodeJSON(a); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+type StaticAccount struct {
+	Name        string
+	SecretType  string
+	RawBindings string
+	Bindings    ResourceBindings
+	gcputil.ServiceAccountId
+
+	TokenGen *TokenGenerator
+}
+
+func (a *StaticAccount) boundResources() *gcpAccountResources {
+	return &gcpAccountResources{
+		accountId: a.ServiceAccountId,
+		bindings:  a.Bindings,
+		tokenGen:  a.TokenGen,
+	}
+}
+
+func (a *StaticAccount) bindingHash() string {
+	return getStringHash(a.RawBindings)
+}
+
+func (a *StaticAccount) validate() error {
+	err := &multierror.Error{}
+	if a.Name == "" {
+		err = multierror.Append(err, errors.New("static account name is empty"))
+	}
+
+	if a.SecretType == "" {
+		err = multierror.Append(err, errors.New("static account secret type is empty"))
+	}
+
+	if a.EmailOrId == "" {
+		err = multierror.Append(err, fmt.Errorf("static account must have service account email"))
+	}
+
+	switch a.SecretType {
+	case SecretTypeAccessToken:
+		if a.TokenGen == nil {
+			err = multierror.Append(err, fmt.Errorf("access token static account should have initialized token generator"))
+		} else if len(a.TokenGen.Scopes) == 0 {
+			err = multierror.Append(err, fmt.Errorf("access token static account should have defined scopes"))
+		}
+	case SecretTypeKey:
+		break
+	default:
+		err = multierror.Append(err, fmt.Errorf("unknown secret type: %s", a.SecretType))
+	}
+	return err.ErrorOrNil()
+}
+
+func (a *StaticAccount) save(ctx context.Context, s logical.Storage) error {
+	if err := a.validate(); err != nil {
+		return err
+	}
+
+	entry, err := logical.StorageEntryJSON(fmt.Sprintf("%s/%s", staticAccountStoragePrefix, a.Name), a)
+	if err != nil {
+		return err
+	}
+
+	return s.Put(ctx, entry)
+}
+
+func (b *backend) tryDeleteStaticAccountResources(ctx context.Context, req *logical.Request, boundResources *gcpAccountResources, walIds []string) []string {
+	return b.tryDeleteGcpAccountResources(ctx, req, boundResources, flagMustKeepServiceAccount, walIds)
+}
+
+func (b *backend) createStaticAccount(ctx context.Context, req *logical.Request, input *inputParams) (err error) {
+	iamAdmin, err := b.IAMAdminClient(req.Storage)
+	if err != nil {
+		return err
+	}
+
+	gcpAcct, err := b.getServiceAccount(iamAdmin, &gcputil.ServiceAccountId{
+		Project:   gcpServiceAccountInferredProject,
+		EmailOrId: input.serviceAccountEmail,
+	})
+
+	if err != nil {
+		if isGoogleAccountNotFoundErr(err) {
+			return fmt.Errorf("unable to create static account, service account %q should exist", input.serviceAccountEmail)
+		}
+		return errwrap.Wrapf(fmt.Sprintf("unable to create static account, could not confirm service account %q exists: {{err}}", input.serviceAccountEmail), err)
+	}
+
+	acctId := gcputil.ServiceAccountId{
+		Project:   gcpAcct.ProjectId,
+		EmailOrId: gcpAcct.Email,
+	}
+
+	// Construct gcpAccountResources references. Note bindings/key are yet to be created.
+	newResources := &gcpAccountResources{
+		accountId: acctId,
+		bindings:  input.bindings,
+	}
+	if input.secretType == SecretTypeAccessToken {
+		newResources.tokenGen = &TokenGenerator{
+			Scopes: input.scopes,
+		}
+	}
+
+	// add WALs for static account resources
+	newWalIds, err := b.addWalsForStaticAccountResources(ctx, req, input.name, newResources)
+	if err != nil {
+		b.tryDeleteWALs(ctx, req.Storage, newWalIds...)
+		return err
+	}
+
+	// Create new IAM bindings.
+	if err := b.createIamBindings(ctx, req, gcpAcct.Email, newResources.bindings); err != nil {
+		return err
+	}
+
+	// Create new token gen if a stubbed tokenGenerator (with scopes) is given.
+	if newResources.tokenGen != nil && len(newResources.tokenGen.Scopes) > 0 {
+		tokenGen, err := b.createNewTokenGen(ctx, req, gcpAcct.Name, newResources.tokenGen.Scopes)
+		if err != nil {
+			return err
+		}
+		newResources.tokenGen = tokenGen
+	}
+
+	// Construct new static account
+	a := &StaticAccount{
+		Name:             input.name,
+		SecretType:       input.secretType,
+		RawBindings:      input.rawBindings,
+		Bindings:         input.bindings,
+		ServiceAccountId: acctId,
+		TokenGen:         newResources.tokenGen,
+	}
+
+	// Save to storage.
+	if err := a.save(ctx, req.Storage); err != nil {
+		return err
+	}
+
+	// We successfully saved the new static account so try cleaning up WALs
+	// that would rollback the GCP resources (will no-op if still in use)
+	b.tryDeleteWALs(ctx, req.Storage, newWalIds...)
+	return err
+}
+
+func (b *backend) updateStaticAccount(ctx context.Context, req *logical.Request, a *StaticAccount, updateInput *inputParams) (warnings []string, err error) {
+	iamAdmin, err := b.IAMAdminClient(req.Storage)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = b.getServiceAccount(iamAdmin, &a.ServiceAccountId)
+	if err != nil {
+		if isGoogleAccountNotFoundErr(err) {
+			return nil, fmt.Errorf("unable to update static account, could not find service account %q", a.ResourceName())
+		}
+		return nil, errwrap.Wrapf(fmt.Sprintf("unable to create static account, could not confirm service account %q exists: {{err}}", a.ResourceName()), err)
+	}
+
+	var walIds []string
+	madeChange := false
+
+	if updateInput.hasBindings && a.bindingHash() != updateInput.rawBindings {
+		b.Logger().Debug("detected bindings change, updating bindings for static account")
+		newBindings := updateInput.bindings
+
+		bindingWals, err := b.updateBindingsForStaticAccount(ctx, req, a, newBindings)
+		if err != nil {
+			return nil, err
+		}
+		walIds = append(walIds, bindingWals...)
+
+		a.RawBindings = updateInput.rawBindings
+		a.Bindings = newBindings
+		madeChange = true
+	}
+
+	if a.SecretType == "access_token" {
+		if a.TokenGen == nil {
+			return nil, fmt.Errorf("unexpected invalid access_token static account has no TokenGen")
+		}
+		if !strutil.EquivalentSlices(updateInput.scopes, a.TokenGen.Scopes) {
+			b.Logger().Debug("detected scopes change, updating scopes for static account")
+			a.TokenGen.Scopes = updateInput.scopes
+			madeChange = true
+		}
+	}
+
+	if !madeChange {
+		return []string{"no changes to bindings or token_scopes detected, no update needed"}, nil
+	}
+
+	if err := a.save(ctx, req.Storage); err != nil {
+		return nil, err
+	}
+
+	b.tryDeleteWALs(ctx, req.Storage, walIds...)
+	return
+
+}
+
+func (b *backend) updateBindingsForStaticAccount(ctx context.Context, req *logical.Request, a *StaticAccount, newBindings ResourceBindings) ([]string, error) {
+	oldBindings := a.Bindings
+	bindsToAdd := newBindings.sub(oldBindings)
+	bindsToRemove := oldBindings.sub(newBindings)
+
+	b.Logger().Debug("updating bindings for static account")
+	walIds, err := b.addWalsForStaticAccountBindings(ctx, req, a, bindsToAdd, bindsToRemove)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.createIamBindings(ctx, req, a.EmailOrId, bindsToAdd); err != nil {
+		return nil, err
+	}
+
+	if err := b.removeBindings(ctx, req, a.EmailOrId, bindsToRemove); err != nil {
+		return nil, err
+	}
+
+	return walIds, nil
+}
+
+// addWalsForStaticAccountResources creates WALs to clean up a roleset's service account, bindings, and a key if needed.
+func (b *backend) addWalsForStaticAccountResources(ctx context.Context, req *logical.Request, staticAcctName string, boundResources *gcpAccountResources) (walIds []string, err error) {
+	if boundResources == nil {
+		b.Logger().Debug("skip WALs for nil GCP account resources")
+		return nil, nil
+	}
+
+	walIds = make([]string, 0, len(boundResources.bindings)+1)
+	for resName, roles := range boundResources.bindings {
+		walId, err := framework.PutWAL(ctx, req.Storage, walTypeIamPolicyDiff, &walIamPolicyStaticAccount{
+			StaticAccount: staticAcctName,
+			AccountId:     boundResources.accountId,
+			Resource:      resName,
+			RolesAdded:    roles.ToSlice(),
+		})
+		if err != nil {
+			return walIds, errwrap.Wrapf("unable to create WAL entry to clean up service account bindings: {{err}}", err)
+		}
+		walIds = append(walIds, walId)
+	}
+
+	if boundResources.tokenGen != nil {
+		walId, err := b.addWalStaticAccountServiceAccountKey(ctx, req, staticAcctName, &boundResources.accountId, boundResources.tokenGen.KeyName)
+		if err != nil {
+			return walIds, err
+		}
+		walIds = append(walIds, walId)
+	}
+	return walIds, nil
+}
+
+func (b *backend) addWalsForStaticAccountBindings(ctx context.Context, req *logical.Request, a *StaticAccount, removed, added ResourceBindings) (walIds []string, err error) {
+	walIds = make([]string, 0, len(removed)+len(added))
+
+	// Add WALs for resources in added bindings
+	for resource, rolesAdded := range added {
+		walEntry := &walIamPolicyStaticAccount{
+			StaticAccount: a.Name,
+			AccountId:     a.ServiceAccountId,
+			Resource:      resource,
+			RolesAdded:    rolesAdded.ToSlice(),
+		}
+		if rolesRemoved, ok := removed[resource]; ok {
+			walEntry.RolesRemoved = rolesRemoved.ToSlice()
+		}
+		walId, err := framework.PutWAL(ctx, req.Storage, walTypeIamPolicyDiff, walEntry)
+		if err != nil {
+			return walIds, errwrap.Wrapf("unable to create WAL entry to clean up service account bindings: {{err}}", err)
+		}
+		walIds = append(walIds, walId)
+	}
+
+	// Add WALs for resources in removed bindings not in added bindings.
+	for resource, rolesRemoved := range removed {
+		if _, ok := added[resource]; ok {
+			continue
+		}
+		walEntry := &walIamPolicyStaticAccount{
+			StaticAccount: a.Name,
+			AccountId:     a.ServiceAccountId,
+			Resource:      resource,
+			RolesRemoved:  rolesRemoved.ToSlice(),
+		}
+
+		walId, err := framework.PutWAL(ctx, req.Storage, walTypeIamPolicyDiff, walEntry)
+		if err != nil {
+			return walIds, errwrap.Wrapf("unable to create WAL entry to clean up service account bindings: {{err}}", err)
+		}
+		walIds = append(walIds, walId)
+	}
+
+	return walIds, nil
+}
+
+// addWalStaticAccountServiceAccountKey creates WAL to clean up a static account's service account key (for access tokens) if needed.
+func (b *backend) addWalStaticAccountServiceAccountKey(ctx context.Context, req *logical.Request, acct string, accountId *gcputil.ServiceAccountId, keyName string) (string, error) {
+	if accountId == nil {
+		return "", fmt.Errorf("given nil account ID for WAL for roleset service account key")
+	}
+
+	b.Logger().Debug("add WAL for service account key", "account", accountId.ResourceName(), "keyName", keyName)
+
+	walId, err := framework.PutWAL(ctx, req.Storage, walTypeAccount, &walAccountKey{
+		StaticAccount:      acct,
+		ServiceAccountName: accountId.ResourceName(),
+		KeyName:            keyName,
+	})
+	if err != nil {
+		return "", errwrap.Wrapf("unable to create WAL entry to clean up service account key: {{err}}", err)
+	}
+	return walId, nil
+}


### PR DESCRIPTION
This PR backports a feature from #107 which adds support for using existing service accounts for key and token generation.

The following steps were taken:
1. `git checkout release/vault-1.8.x`
2. `git checkout -b backport-pr-107-1.8.0`
3. `git cherry-pick 40f93fe`