### PR TITLE
Fixes panic in service account policy rollback

### DIFF
--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -202,7 +202,7 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 	if err != nil {
 		return err
 	}
-	if rs.AccountId != nil && rs.AccountId.ResourceName() == entry.AccountId.ResourceName() {
+	if rs != nil && rs.AccountId != nil && rs.AccountId.ResourceName() == entry.AccountId.ResourceName() {
 		rolesInUse = rs.Bindings[entry.Resource]
 	}
 


### PR DESCRIPTION
## Overview

This PR fixes a panic in `serviceAccountPolicyRollback` by restoring a nil check that was removed in https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/107.

See that the nil check existed in the [PR diff](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/107/files#diff-dbadd49428bf26a2141c41ab4e8e094332479c68e16763818fb2e3d39c0c6686L178).

## Testing

I was able to reproduce the issue and verify that the panic no longer occurs by causing a partial failure when creating a roleset.

Steps taken:
1. Create a new roleset
2. Hit debug breakpoint before [storage write](https://github.com/hashicorp/vault-plugin-secrets-gcp/blob/master/plugin/role_set.go#L184)
3. Stop Vault storage (postgresql container)
4. Play through debug breakpoint causing storage write failure
5. Start Vault storage
6. Wait for WAL rollback to step through `serviceAccountPolicyRollback` behavior
