### PR TITLE
Backport 1.8.x: Fixes panic in service account policy rollback (#121)

### DIFF
--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -202,7 +202,7 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 	if err != nil {
 		return err
 	}
-	if rs.AccountId != nil && rs.AccountId.ResourceName() == entry.AccountId.ResourceName() {
+	if rs != nil && rs.AccountId != nil && rs.AccountId.ResourceName() == entry.AccountId.ResourceName() {
 		rolesInUse = rs.Bindings[entry.Resource]
 	}
 


### PR DESCRIPTION
This PR backports a bug fix from #121.

The following steps were taken:
1. `git checkout release/vault-1.8.x`
2. `git checkout -b backport-pr-121-1.8.x`
3. `git cherry-pick 7c46f127e0ff41d5111d5bb5d06266c224671702`