### PR TITLE
Fixes roleset bindings for BigQuery datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Next
 
+## v0.11.1
+### Unreleased
+
+BUG FIXES:
+
+* Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
+
+## v0.10.3
+### Unreleased
+
+BUG FIXES:
+
+* Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
+
 ## 0.8.1
 ### December 14, 2020
 

--- a/plugin/iamutil/dataset_resource_test.go
+++ b/plugin/iamutil/dataset_resource_test.go
@@ -210,7 +210,7 @@ func getTestFixtures() (*Policy, *Dataset) {
 func testResource() *DatasetResource {
 	return &DatasetResource{
 		relativeId: &gcputil.RelativeResourceName{
-			Name:    "dataset",
+			Name:    "datasets",
 			TypeKey: "projects/datasets",
 			IdTuples: map[string]string{
 				"projects": "project",

--- a/plugin/iamutil/dataset_resource_test.go
+++ b/plugin/iamutil/dataset_resource_test.go
@@ -211,7 +211,7 @@ func testResource() *DatasetResource {
 	return &DatasetResource{
 		relativeId: &gcputil.RelativeResourceName{
 			Name:    "dataset",
-			TypeKey: "projects/dataset",
+			TypeKey: "projects/datasets",
 			IdTuples: map[string]string{
 				"projects": "project",
 				"datasets": "dataset",

--- a/plugin/iamutil/resource_parser.go
+++ b/plugin/iamutil/resource_parser.go
@@ -125,7 +125,7 @@ func (apis GeneratedResources) Parse(rawName string) (Resource, error) {
 		return nil, err
 	}
 	switch cfg.TypeKey {
-	case "projects/dataset":
+	case "projects/datasets":
 		return &DatasetResource{relativeId: relName, config: cfg}, nil
 	default:
 		return &IamResource{relativeId: relName, config: cfg}, nil

--- a/plugin/iamutil/resource_parser_test.go
+++ b/plugin/iamutil/resource_parser_test.go
@@ -13,7 +13,7 @@ import (
 
 var letters = "ABCDEFGHIJKLMNOP"
 
-func TestEnabledIamResources_RelativeName(t *testing.T) {
+func TestEnabledResources_RelativeName(t *testing.T) {
 	enabledApis := GetEnabledResources()
 
 	for resourceType, services := range generatedResources {
@@ -39,10 +39,8 @@ func TestEnabledIamResources_RelativeName(t *testing.T) {
 			}
 
 			if resource != nil {
-				if r, ok := resource.(*IamResource); ok {
-					if err = verifyResource(resourceType, r); err != nil {
-						t.Errorf("could not verify resource for relative resource name %q: %sv", testRelName, err)
-					}
+				if err = verifyResource(resourceType, resource); err != nil {
+					t.Errorf("could not verify resource for relative resource name %q: %sv", testRelName, err)
 				}
 			}
 		} else if resource != nil || err == nil {
@@ -52,7 +50,7 @@ func TestEnabledIamResources_RelativeName(t *testing.T) {
 	}
 }
 
-func TestEnabledIamResources_FullName(t *testing.T) {
+func TestEnabledResources_FullName(t *testing.T) {
 	enabledApis := GetEnabledResources()
 
 	for resourceType, services := range generatedResources {
@@ -69,11 +67,9 @@ func TestEnabledIamResources_FullName(t *testing.T) {
 					t.Errorf("failed to get resource for full resource name %s (type: %s): %v", testFullName, resourceType, err)
 					continue
 				}
-				if r, ok := resource.(*IamResource); ok {
-					if err = verifyResource(resourceType, r); err != nil {
-						t.Errorf("could not verify resource for relative resource name %s: %v", testFullName, err)
-						continue
-					}
+				if err = verifyResource(resourceType, resource); err != nil {
+					t.Errorf("could not verify resource for relative resource name %s: %v", testFullName, err)
+					continue
 				}
 			} else if resource != nil || err == nil {
 				t.Errorf("expected error for using full resource name %s (type: %s), got resource:\n %v\n", testFullName, resourceType, resource)
@@ -230,13 +226,13 @@ func getFakeId(resourceType string) string {
 	return strings.Trim(fakeId, "/")
 }
 
-func verifyResource(rType string, resource *IamResource) (err error) {
+func verifyResource(rType string, resource Resource) (err error) {
 	var req *http.Request
-	if resource.relativeId.TypeKey != rType {
-		return fmt.Errorf("expected resource type %s, actual resource has different type %s", rType, resource.relativeId.TypeKey)
+	if resource.GetRelativeId().TypeKey != rType {
+		return fmt.Errorf("expected resource type %s, actual resource has different type %s", rType, resource.GetRelativeId().TypeKey)
 	}
 
-	req, err = constructRequest(resource, &resource.config.GetMethod, nil)
+	req, err = constructRequest(resource, &resource.GetConfig().GetMethod, nil)
 	if err != nil {
 		return errwrap.Wrapf("unable to construct GetIamPolicyRequest: {{err}}", err)
 	}
@@ -244,7 +240,7 @@ func verifyResource(rType string, resource *IamResource) (err error) {
 		return err
 	}
 
-	req, err = constructRequest(resource, &resource.config.SetMethod, strings.NewReader("{}"))
+	req, err = constructRequest(resource, &resource.GetConfig().SetMethod, strings.NewReader("{}"))
 	if err != nil {
 		return errwrap.Wrapf("unable to construct SetIamPolicyRequest: {{err}}", err)
 	}

--- a/plugin/iamutil/resource_parser_test.go
+++ b/plugin/iamutil/resource_parser_test.go
@@ -39,8 +39,10 @@ func TestEnabledIamResources_RelativeName(t *testing.T) {
 			}
 
 			if resource != nil {
-				if err = verifyResource(resourceType, resource.(*IamResource)); err != nil {
-					t.Errorf("could not verify resource for relative resource name %q: %sv", testRelName, err)
+				if r, ok := resource.(*IamResource); ok {
+					if err = verifyResource(resourceType, r); err != nil {
+						t.Errorf("could not verify resource for relative resource name %q: %sv", testRelName, err)
+					}
 				}
 			}
 		} else if resource != nil || err == nil {
@@ -67,9 +69,11 @@ func TestEnabledIamResources_FullName(t *testing.T) {
 					t.Errorf("failed to get resource for full resource name %s (type: %s): %v", testFullName, resourceType, err)
 					continue
 				}
-				if err = verifyResource(resourceType, resource.(*IamResource)); err != nil {
-					t.Errorf("could not verify resource for relative resource name %s: %v", testFullName, err)
-					continue
+				if r, ok := resource.(*IamResource); ok {
+					if err = verifyResource(resourceType, r); err != nil {
+						t.Errorf("could not verify resource for relative resource name %s: %v", testFullName, err)
+						continue
+					}
 				}
 			} else if resource != nil || err == nil {
 				t.Errorf("expected error for using full resource name %s (type: %s), got resource:\n %v\n", testFullName, resourceType, resource)


### PR DESCRIPTION
## Overview

This PR fixes roleset [bindings](https://www.vaultproject.io/api-docs/secret/gcp#bindings) scoped to BigQuery datasets. There was a typo in the switch case when detecting the key type of the resource. You can see that the correct key is `projects/datasets` on [resource_overrides.go#L12](https://github.com/hashicorp/vault-plugin-secrets-gcp/blob/main/plugin/iamutil/internal/resource_overrides.go#L12).

Fixes #96
Fixes https://github.com/hashicorp/vault/issues/10923

## Testing

I manually tested that the service account principal created for the Vault roleset has the "BigQuery Data Viewer" scoped to the specified BigQuery dataset.

The following bindings were used:
```
vault write gcp/roleset/bigquery-binding \
    project="austin-gebauer" \
    secret_type="service_account_key"  \
    bindings=-<<EOF
    resource "//bigquery.googleapis.com/projects/austin-gebauer/datasets/test_vault_bindings_dataset" {
     	roles = [
            "roles/bigquery.dataViewer",
        ]
    }
EOF
```