### PR TITLE
Backport 1.8.x: Fixes roleset bindings for BigQuery datasets (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Next
 
+## v0.11.1
+### Unreleased
+
+BUG FIXES:
+
+* Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
+
+## v0.10.3
+### Unreleased
+
+BUG FIXES:
+
+* Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
+
 ## 0.8.1
 ### December 14, 2020
 

--- a/plugin/iamutil/dataset_resource_test.go
+++ b/plugin/iamutil/dataset_resource_test.go
@@ -210,8 +210,8 @@ func getTestFixtures() (*Policy, *Dataset) {
 func testResource() *DatasetResource {
 	return &DatasetResource{
 		relativeId: &gcputil.RelativeResourceName{
-			Name:    "dataset",
-			TypeKey: "projects/dataset",
+			Name:    "datasets",
+			TypeKey: "projects/datasets",
 			IdTuples: map[string]string{
 				"projects": "project",
 				"datasets": "dataset",

--- a/plugin/iamutil/resource_parser.go
+++ b/plugin/iamutil/resource_parser.go
@@ -125,7 +125,7 @@ func (apis GeneratedResources) Parse(rawName string) (Resource, error) {
 		return nil, err
 	}
 	switch cfg.TypeKey {
-	case "projects/dataset":
+	case "projects/datasets":
 		return &DatasetResource{relativeId: relName, config: cfg}, nil
 	default:
 		return &IamResource{relativeId: relName, config: cfg}, nil

--- a/plugin/iamutil/resource_parser_test.go
+++ b/plugin/iamutil/resource_parser_test.go
@@ -13,7 +13,7 @@ import (
 
 var letters = "ABCDEFGHIJKLMNOP"
 
-func TestEnabledIamResources_RelativeName(t *testing.T) {
+func TestEnabledResources_RelativeName(t *testing.T) {
 	enabledApis := GetEnabledResources()
 
 	for resourceType, services := range generatedResources {
@@ -39,7 +39,7 @@ func TestEnabledIamResources_RelativeName(t *testing.T) {
 			}
 
 			if resource != nil {
-				if err = verifyResource(resourceType, resource.(*IamResource)); err != nil {
+				if err = verifyResource(resourceType, resource); err != nil {
 					t.Errorf("could not verify resource for relative resource name %q: %sv", testRelName, err)
 				}
 			}
@@ -50,7 +50,7 @@ func TestEnabledIamResources_RelativeName(t *testing.T) {
 	}
 }
 
-func TestEnabledIamResources_FullName(t *testing.T) {
+func TestEnabledResources_FullName(t *testing.T) {
 	enabledApis := GetEnabledResources()
 
 	for resourceType, services := range generatedResources {
@@ -67,7 +67,7 @@ func TestEnabledIamResources_FullName(t *testing.T) {
 					t.Errorf("failed to get resource for full resource name %s (type: %s): %v", testFullName, resourceType, err)
 					continue
 				}
-				if err = verifyResource(resourceType, resource.(*IamResource)); err != nil {
+				if err = verifyResource(resourceType, resource); err != nil {
 					t.Errorf("could not verify resource for relative resource name %s: %v", testFullName, err)
 					continue
 				}
@@ -226,13 +226,13 @@ func getFakeId(resourceType string) string {
 	return strings.Trim(fakeId, "/")
 }
 
-func verifyResource(rType string, resource *IamResource) (err error) {
+func verifyResource(rType string, resource Resource) (err error) {
 	var req *http.Request
-	if resource.relativeId.TypeKey != rType {
-		return fmt.Errorf("expected resource type %s, actual resource has different type %s", rType, resource.relativeId.TypeKey)
+	if resource.GetRelativeId().TypeKey != rType {
+		return fmt.Errorf("expected resource type %s, actual resource has different type %s", rType, resource.GetRelativeId().TypeKey)
 	}
 
-	req, err = constructRequest(resource, &resource.config.GetMethod, nil)
+	req, err = constructRequest(resource, &resource.GetConfig().GetMethod, nil)
 	if err != nil {
 		return errwrap.Wrapf("unable to construct GetIamPolicyRequest: {{err}}", err)
 	}
@@ -240,7 +240,7 @@ func verifyResource(rType string, resource *IamResource) (err error) {
 		return err
 	}
 
-	req, err = constructRequest(resource, &resource.config.SetMethod, strings.NewReader("{}"))
+	req, err = constructRequest(resource, &resource.GetConfig().SetMethod, strings.NewReader("{}"))
 	if err != nil {
 		return errwrap.Wrapf("unable to construct SetIamPolicyRequest: {{err}}", err)
 	}


### PR DESCRIPTION
This PR backports a bug fix from #130.

Steps:
1. `git checkout release/vault-1.8.x`
2. `git checkout -b backport-pr-130-1.8.x`
3. `git cherry-pick 2d8183f511aaa65418a3b9fa7a2d54ef3fa2c1e7`
