### PR TITLE
Refactor multierror handling in resource generation

### DIFF
--- a/plugin/iamutil/resource_parser.go
+++ b/plugin/iamutil/resource_parser.go
@@ -1,4 +1,4 @@
-//go:generate go run internal/generate_iam.go
+//go:generate go run internal/generate_resources.go
 package iamutil
 
 import (


### PR DESCRIPTION
# Overview
This PR is to refactor error variables in the resource generation code. Previously, the variable `err` was being reused in multiple places, and this will separate out inner-scoped errors with an outer-scope multierror.

Additionally, changed the `go generate` magic comment to reference the correct file now.