### PR TITLE
Fix bug where error was not reported for invalid bindings

### DIFF
--- a/plugin/gcp_account_resources.go
+++ b/plugin/gcp_account_resources.go
@@ -109,7 +109,7 @@ func (b *backend) createIamBindings(ctx context.Context, req *logical.Request, s
 		b.Logger().Debug("getting IAM policy for resource name", "name", resourceName)
 		p, err := resource.GetIamPolicy(ctx, apiHandle)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		b.Logger().Debug("got IAM policy for resource name", "name", resourceName)

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -318,7 +318,7 @@ func (b *backend) pathRoleSetCreateUpdate(ctx context.Context, req *logical.Requ
 		warnings = append(warnings, updateWarns...)
 	}
 	if err != nil {
-		return logical.ErrorResponse(err.Error()), nil
+		return logical.ErrorResponse(err.Error()), err
 	} else if warnings != nil && len(warnings) > 0 {
 		return &logical.Response{Warnings: warnings}, nil
 	}

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -318,7 +318,7 @@ func (b *backend) pathRoleSetCreateUpdate(ctx context.Context, req *logical.Requ
 		warnings = append(warnings, updateWarns...)
 	}
 	if err != nil {
-		return logical.ErrorResponse(err.Error()), err
+		return logical.ErrorResponse(err.Error()), nil
 	} else if warnings != nil && len(warnings) > 0 {
 		return &logical.Response{Warnings: warnings}, nil
 	}

--- a/plugin/path_role_set_secrets_test.go
+++ b/plugin/path_role_set_secrets_test.go
@@ -20,6 +20,11 @@ func TestSecrets_getRoleSetKey(t *testing.T) {
 	testGetRoleSetKey(t, rsName, fmt.Sprintf("roleset/%s/key", rsName))
 }
 
+func TestSecrets_roleSetBadResource(t *testing.T) {
+	rsName := "test-bad-resource"
+	testGetRoleSetBadResource(t, rsName, fmt.Sprintf("roleset/%s", rsName))
+}
+
 // Test deprecated path still works
 func TestSecretsDeprecated_getRoleSetAccessToken(t *testing.T) {
 	rsName := "test-gentoken"
@@ -127,6 +132,32 @@ func testGetRoleSetKey(t *testing.T, rsName, path string) {
 	// Cleanup: Delete role set
 	testRoleSetDelete(t, td, rsName, sa.Name)
 	verifyProjectBindingsRemoved(t, td, sa.Email, testRoles)
+}
+
+func testGetRoleSetBadResource(t *testing.T, rsName, path string) {
+	secretType := SecretTypeKey
+
+	td := setupTest(t, "0s", "2h")
+	defer cleanupRoleset(t, td, rsName, testRoles)
+
+	projRes := fmt.Sprintf(testProjectResourceTemplate, rsName)
+
+	// Create new role set
+	expectedBinds := ResourceBindings{projRes: testRoles}
+	bindsRaw, err := util.BindingsHCL(expectedBinds)
+	if err != nil {
+		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
+	}
+	_, err = testRoleSetCreateRaw(t, td, rsName,
+		map[string]interface{}{
+			"secret_type": secretType,
+			"project":     td.Project,
+			"bindings":    bindsRaw,
+		})
+
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
 }
 
 func TestSecrets_GenerateKeyConfigTTL(t *testing.T) {

--- a/plugin/path_role_set_secrets_test.go
+++ b/plugin/path_role_set_secrets_test.go
@@ -148,14 +148,14 @@ func testGetRoleSetBadResource(t *testing.T, rsName, path string) {
 	if err != nil {
 		t.Fatalf("unable to convert resource bindings to HCL string: %v", err)
 	}
-	_, err = testRoleSetCreateRaw(t, td, rsName,
+	resp, _ := testRoleSetCreateRaw(t, td, rsName,
 		map[string]interface{}{
 			"secret_type": secretType,
 			"project":     td.Project,
 			"bindings":    bindsRaw,
 		})
 
-	if err == nil {
+	if !resp.IsError() {
 		t.Fatal("expected error, got none")
 	}
 }

--- a/plugin/path_role_set_test.go
+++ b/plugin/path_role_set_test.go
@@ -506,6 +506,15 @@ func testRoleSetCreate(t *testing.T, td *testData, rsName string, d map[string]i
 	}
 }
 
+func testRoleSetCreateRaw(t *testing.T, td *testData, rsName string, d map[string]interface{}) (*logical.Response, error) {
+	return td.B.HandleRequest(context.Background(), &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      fmt.Sprintf("roleset/%s", rsName),
+		Data:      d,
+		Storage:   td.S,
+	})
+}
+
 func testRoleSetRead(t *testing.T, td *testData, rsName string) map[string]interface{} {
 	resp, err := td.B.HandleRequest(context.Background(), &logical.Request{
 		Operation: logical.ReadOperation,


### PR DESCRIPTION
Two errors were being swallowed causing Vault to report a successful operation, however, bindings were incorrect and it resulted in a service account with no bindings. Fixed these errors and added a test ensuring an error is returned.

Fixes #135.