### PR TITLE
Fixes duplicate static account key creation from performance secondary clusters

### DIFF
--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -49,10 +49,14 @@ func pathRoleSet(b *backend) *framework.Path {
 				Callback: b.pathRoleSetRead,
 			},
 			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetCreateUpdate,
+				Callback:                    b.pathRoleSetCreateUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetCreateUpdate,
+				Callback:                    b.pathRoleSetCreateUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathRoleSetHelpSyn,
@@ -87,7 +91,9 @@ func pathRoleSetRotateAccount(b *backend) *framework.Path {
 		ExistenceCheck: b.pathRoleSetExistenceCheck("name"),
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetRotateAccount,
+				Callback:                    b.pathRoleSetRotateAccount,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathRoleSetRotateAccountHelpSyn,
@@ -107,7 +113,9 @@ func pathRoleSetRotateKey(b *backend) *framework.Path {
 		ExistenceCheck: b.pathRoleSetExistenceCheck("name"),
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetRotateKey,
+				Callback:                    b.pathRoleSetRotateKey,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathRoleSetRotateKeyHelpSyn,

--- a/plugin/path_static_account.go
+++ b/plugin/path_static_account.go
@@ -51,10 +51,14 @@ func pathStaticAccount(b *backend) *framework.Path {
 				Callback: b.pathStaticAccountRead,
 			},
 			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathStaticAccountCreate,
+				Callback:                    b.pathStaticAccountCreate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathStaticAccountUpdate,
+				Callback:                    b.pathStaticAccountUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathStaticAccountHelpSyn,

--- a/plugin/path_static_account_rotate_key.go
+++ b/plugin/path_static_account_rotate_key.go
@@ -3,6 +3,7 @@ package gcpsecrets
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -19,7 +20,9 @@ func pathStaticAccountRotateKey(b *backend) *framework.Path {
 		ExistenceCheck: b.pathStaticAccountExistenceCheck,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathStaticAccountRotateKey,
+				Callback:                    b.pathStaticAccountRotateKey,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathStaticAccountRotateKeyHelpSyn,


### PR DESCRIPTION
## Overview

This PR fixes an issue that caused duplicate service account keys to be generated when creating a static account (`secret_type=access_token`) from a Vault performance secondary cluster. WAL writes in this secrets engine usually result in request forwarding (via [ErrReadOnly](https://github.com/hashicorp/vault/blob/main/sdk/logical/storage.go#L17)) on performance standby instances. However, the active instance in the performance secondary cluster is capable of writing WALs, so the request handler would partially succeed. This would result in duplicate services account keys once the request was finally forwarded due to a different storage write.

I've also added explicit request forwarding for other locations in the code that were implicitly forwarding requests on performance standbys since they could result in similar issues.

## Testing

I tested this fix using a performance secondary cluster. Two service account keys are no longer being generated when writing a static account.