### PR TITLE
Backport 1.10.x: Fixes duplicate static account key creation from performance secondary clusters (#144)

### DIFF
--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -49,10 +49,14 @@ func pathRoleSet(b *backend) *framework.Path {
 				Callback: b.pathRoleSetRead,
 			},
 			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetCreateUpdate,
+				Callback:                    b.pathRoleSetCreateUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetCreateUpdate,
+				Callback:                    b.pathRoleSetCreateUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathRoleSetHelpSyn,
@@ -87,7 +91,9 @@ func pathRoleSetRotateAccount(b *backend) *framework.Path {
 		ExistenceCheck: b.pathRoleSetExistenceCheck("name"),
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetRotateAccount,
+				Callback:                    b.pathRoleSetRotateAccount,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathRoleSetRotateAccountHelpSyn,
@@ -107,7 +113,9 @@ func pathRoleSetRotateKey(b *backend) *framework.Path {
 		ExistenceCheck: b.pathRoleSetExistenceCheck("name"),
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathRoleSetRotateKey,
+				Callback:                    b.pathRoleSetRotateKey,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathRoleSetRotateKeyHelpSyn,

--- a/plugin/path_static_account.go
+++ b/plugin/path_static_account.go
@@ -51,10 +51,14 @@ func pathStaticAccount(b *backend) *framework.Path {
 				Callback: b.pathStaticAccountRead,
 			},
 			logical.CreateOperation: &framework.PathOperation{
-				Callback: b.pathStaticAccountCreate,
+				Callback:                    b.pathStaticAccountCreate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathStaticAccountUpdate,
+				Callback:                    b.pathStaticAccountUpdate,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathStaticAccountHelpSyn,

--- a/plugin/path_static_account_rotate_key.go
+++ b/plugin/path_static_account_rotate_key.go
@@ -3,6 +3,7 @@ package gcpsecrets
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 )
@@ -19,7 +20,9 @@ func pathStaticAccountRotateKey(b *backend) *framework.Path {
 		ExistenceCheck: b.pathStaticAccountExistenceCheck,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathStaticAccountRotateKey,
+				Callback:                    b.pathStaticAccountRotateKey,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 		HelpSynopsis:    pathStaticAccountRotateKeyHelpSyn,


### PR DESCRIPTION
This PR backports #144 into release/vault-1.10.x.

Steps:
```sh
git checkout release/vault-1.10.x
git checkout -b backport-pr-144-1.10.x
git cherry-pick 3235c5de81b15c9a9db930651be7036e19aaf787
```