### PR TITLE
Updates changelog for v0.13.1 and v0.12.1 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ IMPROVEMENTS:
 
 * Updates dependencies: `google.golang.org/api@v0.83.0`, `github.com/hashicorp/go-gcp-common@v0.8.0` [[GH-142](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/142)]
 
+## v0.13.1
+### August 2, 2022
+
+BUG FIXES:
+
+* Fixes duplicate static account key creation from performance secondary clusters [[GH-144](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/144)]
+
+## v0.12.1
+### August 2, 2022
+
+BUG FIXES:
+
+* Fixes duplicate static account key creation from performance secondary clusters [[GH-144](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/144)]
+
 ## v0.11.1
 ### January 3, 2022
 


### PR DESCRIPTION
This PR updates the changelog with entries for the `v0.13.1` and `v0.12.1` releases.