### PR TITLE
Adds simple retry loop to improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,42 @@
-## Next
+## Unreleased
+
+## v0.14.0
 
 IMPROVEMENTS:
 
 * Updates dependencies: `google.golang.org/api@v0.83.0`, `github.com/hashicorp/go-gcp-common@v0.8.0` [[GH-142](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/142)]
 
 ## v0.13.1
-### August 2, 2022
 
 BUG FIXES:
 
 * Fixes duplicate static account key creation from performance secondary clusters [[GH-144](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/144)]
 
 ## v0.12.1
-### August 2, 2022
 
 BUG FIXES:
 
 * Fixes duplicate static account key creation from performance secondary clusters [[GH-144](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/144)]
 
 ## v0.11.1
-### January 3, 2022
 
 BUG FIXES:
 
 * Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
 
 ## v0.10.3
-### January 3, 2022
 
 BUG FIXES:
 
 * Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
 
 ## v0.9.1
-### January 20, 2022
 
 BUG FIXES:
 
 * Fixes role bindings for BigQuery dataset resources [[GH-130](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/130)]
 
 ## 0.8.1
-### December 14, 2020
 
 IMPROVEMENTS:
 

--- a/plugin/path_role_set_secrets_test.go
+++ b/plugin/path_role_set_secrets_test.go
@@ -121,13 +121,7 @@ func testGetRoleSetKey(t *testing.T, rsName, path string) {
 	testRenewSecretKey(t, td, secret)
 	testRevokeSecretKey(t, td, secret)
 
-	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
-	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
-		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
-	}
-	if k != nil {
-		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
-	}
+	verifyServiceAccountKeyDeleted(t, td.IamAdmin, keyName)
 
 	// Cleanup: Delete role set
 	testRoleSetDelete(t, td, rsName, sa.Name)
@@ -209,14 +203,7 @@ func TestSecrets_GenerateKeyConfigTTL(t *testing.T) {
 	testRenewSecretKey(t, td, resp.Secret)
 	testRevokeSecretKey(t, td, resp.Secret)
 
-	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
-
-	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
-		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
-	}
-	if k != nil {
-		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
-	}
+	verifyServiceAccountKeyDeleted(t, td.IamAdmin, keyName)
 
 	// Cleanup: Delete role set
 	testRoleSetDelete(t, td, rsName, sa.Name)
@@ -272,14 +259,7 @@ func TestSecrets_GenerateKeyTTLOverride(t *testing.T) {
 	testRenewSecretKey(t, td, resp.Secret)
 	testRevokeSecretKey(t, td, resp.Secret)
 
-	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
-
-	if k != nil {
-		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
-	}
-	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
-		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
-	}
+	verifyServiceAccountKeyDeleted(t, td.IamAdmin, keyName)
 
 	// Cleanup: Delete role set
 	testRoleSetDelete(t, td, rsName, sa.Name)
@@ -341,13 +321,7 @@ func TestSecrets_GenerateKeyMaxTTLCheck(t *testing.T) {
 	testRenewSecretKey(t, td, resp.Secret)
 	testRevokeSecretKey(t, td, resp.Secret)
 
-	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
-	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
-		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
-	}
-	if k != nil {
-		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
-	}
+	verifyServiceAccountKeyDeleted(t, td.IamAdmin, keyName)
 
 	// Cleanup: Delete role set
 	testRoleSetDelete(t, td, rsName, sa.Name)

--- a/plugin/path_role_set_test.go
+++ b/plugin/path_role_set_test.go
@@ -688,6 +688,19 @@ func getServiceAccount(t *testing.T, iamAdmin *iam.Service, readData map[string]
 	return sa
 }
 
+func verifyServiceAccountKeyDeleted(t *testing.T, iamAdmin *iam.Service, keyName string) {
+	for attempt := 0; attempt < 10; attempt++ {
+		_, err := iamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
+		if isGoogleAccountKeyNotFoundErr(err) {
+			return
+		}
+
+		t.Logf("%d: waiting for service account key %q to be deleted", attempt, keyName)
+		time.Sleep(1 * time.Second)
+	}
+	t.Fatalf("expected service account key %q to have been deleted", keyName)
+}
+
 func verifyServiceAccountDeleted(t *testing.T, iamAdmin *iam.Service, saName string) {
 	for attempt := 0; attempt < 10; attempt++ {
 		_, err := iamAdmin.Projects.ServiceAccounts.Get(saName).Do()

--- a/plugin/path_static_account_secrets_test.go
+++ b/plugin/path_static_account_secrets_test.go
@@ -130,13 +130,7 @@ func testGetStaticKey(t *testing.T, staticName string, ttl uint64) {
 	testRenewSecretKey(t, td, secret)
 	testRevokeSecretKey(t, td, secret)
 
-	k, err := td.IamAdmin.Projects.ServiceAccounts.Keys.Get(keyName).Do()
-	if err == nil || !isGoogleAccountKeyNotFoundErr(err) {
-		t.Fatalf("expected 404 error from getting deleted key, instead got error: %v", err)
-	}
-	if k != nil {
-		t.Fatalf("expected error as revoked key was deleted, instead got key: %v", k)
-	}
+	verifyServiceAccountKeyDeleted(t, td.IamAdmin, keyName)
 
 	// Cleanup
 	testStaticDelete(t, td, staticName)


### PR DESCRIPTION
This PR improves the acceptance tests by adding a retry loop for checking that a service account key is deleted. The tests would occasionally fail without this because Google doesn't always report the service account key as being deleted immediately.

Additionally, this updates the changelog for the upcoming v0.14.0 tag.