### PR TITLE
Fixes duplicate service account key for rotate root on standby or secondary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ local_environment_setup.sh
 
 # Local .terraform directories
 **/.terraform/*
+.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/plugin/path_config_rotate_root.go
+++ b/plugin/path_config_rotate_root.go
@@ -18,7 +18,9 @@ func pathConfigRotateRoot(b *backend) *framework.Path {
 
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathConfigRotateRootWrite,
+				Callback:                    b.pathConfigRotateRootWrite,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 


### PR DESCRIPTION
## Overview

This PR fixes a bug where a duplicate service account key is created when a rotate root operation is taken on a Vault performance standby or secondary. The reason is that we partially complete the operation on the standby instance, encounter a read-only storage error, then forward the request to the active instance. At that point, the request handling creates another service account key.

This will get backported, tagged, and integrated into Vault.

## Contributor Checklist
- [ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
  - Will add changelog. Other docs not required.
- [ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
