### PR TITLE
Backport: Fixes duplicate service account key for rotate root on standby and secondary (#153)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,12 @@ ui/testem.log
 
 # IAM
 vault-tester.json
+local_environment_setup.sh
+
+# Local .terraform directories
+**/.terraform/*
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*

--- a/plugin/path_config_rotate_root.go
+++ b/plugin/path_config_rotate_root.go
@@ -18,7 +18,9 @@ func pathConfigRotateRoot(b *backend) *framework.Path {
 
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback: b.pathConfigRotateRootWrite,
+				Callback:                    b.pathConfigRotateRootWrite,
+				ForwardPerformanceStandby:   true,
+				ForwardPerformanceSecondary: true,
 			},
 		},
 


### PR DESCRIPTION
This PR backports #153 into the `release/vault-1.11.x` branch.

Steps:
```
git checkout release/vault-1.11.x
git checkout -b backport-pr-153-1.11.x
git cherry-pick 5f1b9af4c7bf3e67ba61f92b49541cd1019ef25d
```
