### PR TITLE
Fixes panic in impersonated account access token handler

### DIFF
--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -45,25 +45,25 @@ func (b *backend) pathImpersonatedAccountAccessToken(ctx context.Context, req *l
 		return nil, err
 	}
 
-	config, err := getConfig(ctx, req.Storage)
+	cfg, err := getConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
 	}
-	if config == nil {
-		return logical.ErrorResponse("configuration for secrets engine does not exist"), nil
+	if cfg == nil {
+		cfg = &config{}
 	}
 
 	warnings := []string{}
 	acctTtl := time.Duration(acct.Ttl) * time.Second
-	if acctTtl > config.MaxTTL {
+	if acctTtl > cfg.MaxTTL {
 		warnings = append(warnings, fmt.Sprintf("using backend max ttl %q which is less than impersonated account ttl %q for token",
-			config.MaxTTL.String(),
+			cfg.MaxTTL.String(),
 			acctTtl.String()))
-		acctTtl = config.MaxTTL
+		acctTtl = cfg.MaxTTL
 	} else if acctTtl == 0 {
 		warnings = append(warnings, fmt.Sprintf("using backend default ttl %q since impersonated account ttl not configured for token",
-			config.TTL.String()))
-		acctTtl = config.TTL
+			cfg.TTL.String()))
+		acctTtl = cfg.TTL
 	}
 
 	tokenSource, err := impersonate.CredentialsTokenSource(ctx, impersonate.CredentialsConfig{

--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -49,6 +49,9 @@ func (b *backend) pathImpersonatedAccountAccessToken(ctx context.Context, req *l
 	if err != nil {
 		return nil, err
 	}
+	if config == nil {
+		return logical.ErrorResponse("configuration for secrets engine does not exist"), nil
+	}
 
 	warnings := []string{}
 	acctTtl := time.Duration(acct.Ttl) * time.Second


### PR DESCRIPTION
## Overview

This PR fixes a panic that occurs when requesting an impersonated account access token before the secrets engine [config](https://developer.hashicorp.com/vault/api-docs/secret/gcp#write-config) is written. I checked other locations in the code where this could occur but didn't find any.

This code is unreleased in Vault, so there is no need to backport it here. 

## Related Issues/Pull Requests
-  #129

