### PR TITLE
Replace usage of useragent.String with useragent.PluginString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+CHANGES:
+
+* Changes user-agent header value to use correct Vault version information and include
+  the plugin type and name in the comment section.
+
 ## v0.14.0
 
 IMPROVEMENTS:

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -2,6 +2,7 @@ package gcpsecrets
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -114,8 +115,7 @@ func Backend() *backend {
 func (b *backend) initialize(ctx context.Context, _ *logical.InitializationRequest) error {
 	pluginEnv, err := b.System().PluginEnv(ctx)
 	if err != nil {
-		b.Logger().Warn("failed to read plugin environment, user-agent will not be set",
-			"error", err)
+		return fmt.Errorf("failed to read plugin environment: %w", err)
 	}
 	b.pluginEnv = pluginEnv
 

--- a/plugin/gcp_account_resources.go
+++ b/plugin/gcp_account_resources.go
@@ -97,7 +97,8 @@ func (b *backend) createIamBindings(ctx context.Context, req *logical.Request, s
 	if err != nil {
 		return err
 	}
-	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
+	apiHandle := iamutil.GetApiHandle(httpC, useragent.PluginString(b.pluginEnv,
+		userAgentPluginName))
 
 	for resourceName, roles := range binds {
 		b.Logger().Debug("setting IAM binding", "resource", resourceName, "roles", roles)
@@ -213,7 +214,8 @@ func (b *backend) removeBindings(ctx context.Context, req *logical.Request, emai
 		return &multierror.Error{Errors: []error{err}}
 	}
 
-	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
+	apiHandle := iamutil.GetApiHandle(httpC, useragent.PluginString(b.pluginEnv,
+		userAgentPluginName))
 
 	for resName, roles := range bindings {
 		resource, err := b.resources.Parse(resName)

--- a/plugin/rollback.go
+++ b/plugin/rollback.go
@@ -222,7 +222,8 @@ func (b *backend) serviceAccountPolicyRollback(ctx context.Context, req *logical
 		return err
 	}
 
-	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
+	apiHandle := iamutil.GetApiHandle(httpC, useragent.PluginString(b.pluginEnv,
+		userAgentPluginName))
 	p, err := r.GetIamPolicy(ctx, apiHandle)
 	if err != nil {
 		if isGoogleAccountNotFoundErr(err) || isGoogleAccountUnauthorizedErr(err) {
@@ -284,7 +285,8 @@ func (b *backend) serviceAccountPolicyDiffRollback(ctx context.Context, req *log
 		return err
 	}
 
-	apiHandle := iamutil.GetApiHandle(httpC, useragent.String())
+	apiHandle := iamutil.GetApiHandle(httpC, useragent.PluginString(b.pluginEnv,
+		userAgentPluginName))
 	p, err := r.GetIamPolicy(ctx, apiHandle)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Overview

This PR replaces usage of [`useragent.String`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L43) with [`useragent.PluginString`](https://github.com/hashicorp/vault/blob/main/sdk/helper/useragent/useragent.go#L58). `useragent.String` has been deprecated. Using `useragent.PluginString` will allow plugins running external to Vault to use correct Vault version information in construction of user-agent request headers regardless of the compiled SDK version.

## Related Issues/Pull Requests
- https://github.com/hashicorp/vault/pull/14229
