### PR TITLE
Fix OpenAPI OperationID conflicts

### DIFF
--- a/plugin/path_impersonated_account.go
+++ b/plugin/path_impersonated_account.go
@@ -69,7 +69,7 @@ func pathImpersonatedAccountList(b *backend) *framework.Path {
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixGoogleCloud,
 			OperationVerb:   "list",
-			OperationSuffix: "impersonated-accounts",
+			OperationSuffix: "impersonated-accounts|impersonated-accounts2",
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -78,7 +78,7 @@ func pathRoleSetList(b *backend) *framework.Path {
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixGoogleCloud,
 			OperationVerb:   "list",
-			OperationSuffix: "rolesets",
+			OperationSuffix: "rolesets|rolesets2",
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{

--- a/plugin/path_static_account.go
+++ b/plugin/path_static_account.go
@@ -80,7 +80,7 @@ func pathStaticAccountList(b *backend) *framework.Path {
 		DisplayAttrs: &framework.DisplayAttributes{
 			OperationPrefix: operationPrefixGoogleCloud,
 			OperationVerb:   "list",
-			OperationSuffix: "static-accounts",
+			OperationSuffix: "static-accounts|static-accounts2",
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{


### PR DESCRIPTION
# Overview

I missed a few Operation ID conflicts in #180. This PR fixes the following:

| Path | Method | OperationID |
| ---- | ------ | ----------- |
| "/{gcp_mount_path}/impersonated-account" | "get" | "google-cloud-list-impersonated-accounts" |
| "/{gcp_mount_path}/impersonated-accounts" | "get" | "google-cloud-list-impersonated-accounts2" |
| "/{gcp_mount_path}/roleset" | "get" | "google-cloud-list-rolesets" |
| "/{gcp_mount_path}/rolesets" | "get" | "google-cloud-list-rolesets2" |
| "/{gcp_mount_path}/static-account" | "get" | "google-cloud-list-static-accounts" |
| "/{gcp_mount_path}/static-accounts" | "get" | "google-cloud-list-static-accounts2" |

# Related Issues/Pull Requests

- #180
