### PR TITLE
Add missing `Query: true` metadata to API definitions

### DIFF
--- a/plugin/path_role_set_secrets.go
+++ b/plugin/path_role_set_secrets.go
@@ -21,15 +21,18 @@ func fieldSchemaRoleSetServiceAccountKey() map[string]*framework.FieldSchema {
 			Type:        framework.TypeString,
 			Description: fmt.Sprintf(`Private key algorithm for service account key - defaults to %s"`, keyAlgorithmRSA2k),
 			Default:     keyAlgorithmRSA2k,
+			Query:       true,
 		},
 		"key_type": {
 			Type:        framework.TypeString,
 			Description: fmt.Sprintf(`Private key type for service account key - defaults to %s"`, privateKeyTypeJson),
 			Default:     privateKeyTypeJson,
+			Query:       true,
 		},
 		"ttl": {
 			Type:        framework.TypeDurationSecond,
 			Description: "Lifetime of the service account key",
+			Query:       true,
 		},
 	}
 }

--- a/plugin/path_static_account_secrets.go
+++ b/plugin/path_static_account_secrets.go
@@ -27,15 +27,18 @@ func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
 				Type:        framework.TypeString,
 				Description: fmt.Sprintf(`Private key algorithm for service account key. Defaults to %s."`, keyAlgorithmRSA2k),
 				Default:     keyAlgorithmRSA2k,
+				Query:       true,
 			},
 			"key_type": {
 				Type:        framework.TypeString,
 				Description: fmt.Sprintf(`Private key type for service account key. Defaults to %s."`, privateKeyTypeJson),
 				Default:     privateKeyTypeJson,
+				Query:       true,
 			},
 			"ttl": {
 				Type:        framework.TypeDurationSecond,
 				Description: "Lifetime of the service account key",
+				Query:       true,
 			},
 		},
 		Operations: map[logical.Operation]framework.OperationHandler{


### PR DESCRIPTION
As described in hashicorp/vault#21949 endpoints with non-path parameters
that can be made use of during ReadOperation callbacks should have those
fields marked as `Query: true` to ensure the OpenAPI spec truly reflects
how the endpoints can be called.

Endpoints concerned:
- gcp/key/{roleset}
- gcp/roleset/{roleset}/key
- gcp/static-account/{name}/key

The OpenAPI operation IDs for these operations that mention
"with-parameters" should also be changed, as they perpetuate
a misunderstanding - both read (GET) and update (POST/PUT) forms of
these APIs are **equally** capable of being used with parameters.
