### PR TITLE
Shuffle around operation IDs to present the best generated client library interface

### DIFF
--- a/plugin/path_role_set_secrets.go
+++ b/plugin/path_role_set_secrets.go
@@ -60,13 +60,13 @@ func pathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-key",
+					OperationSuffix: "roleset-key2",
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-key-with-parameters",
+					OperationSuffix: "roleset-key",
 				},
 			},
 		},
@@ -89,13 +89,13 @@ func deprecatedPathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-key2",
+					OperationSuffix: "roleset-key4",
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-key-with-parameters2",
+					OperationSuffix: "roleset-key3",
 				},
 			},
 		},
@@ -117,13 +117,13 @@ func pathRoleSetSecretAccessToken(b *backend) *framework.Path {
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-access-token",
+					OperationSuffix: "roleset-access-token2",
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-access-token-with-parameters",
+					OperationSuffix: "roleset-access-token",
 				},
 			},
 		},
@@ -146,13 +146,13 @@ func deprecatedPathRoleSetSecretAccessToken(b *backend) *framework.Path {
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-access-token2",
+					OperationSuffix: "roleset-access-token4",
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "roleset-access-token-with-parameters2",
+					OperationSuffix: "roleset-access-token3",
 				},
 			},
 		},

--- a/plugin/path_static_account_secrets.go
+++ b/plugin/path_static_account_secrets.go
@@ -45,13 +45,13 @@ func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountSecretKey,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "static-account-key",
+					OperationSuffix: "static-account-key2",
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountSecretKey,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "static-account-key-with-parameters",
+					OperationSuffix: "static-account-key",
 				},
 			},
 		},
@@ -77,13 +77,13 @@ func pathStaticAccountSecretAccessToken(b *backend) *framework.Path {
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountAccessToken,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "static-account-access-token",
+					OperationSuffix: "static-account-access-token2",
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountAccessToken,
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "static-account-access-token-with-parameters",
+					OperationSuffix: "static-account-access-token",
 				},
 			},
 		},


### PR DESCRIPTION
The `with-parameters` APIs were never actually about being "with
parameters" - it was simply a case of "query parameters" vs. "body
parameters". At the generated client code level, that translates to
"direct method parameters" vs. "parameters in a request struct".

This PR makes the opinionated choice to encourage the PUT/POST, "body
parameters", "request struct" versions over the GET, "query parameters",
"direct method parameters" ones because:

* Direct method parameters are hard to support and additions/removals to
  later.

* The large majority of Vault APIs don't support this duality of
  parameter conventions, so choose the one that is what users will
  encounter most often in other parts of the Vault API surface.
