### PR TITLE
feat: Add support for universe_domain parameter (#242)

### DIFF
--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -44,6 +44,7 @@ func TestConfig(t *testing.T) {
 		"rotation_period":            float64(0),
 		"rotation_schedule":          "",
 		"disable_automated_rotation": false,
+		"universe_domain":            "googleapis.com",
 	}
 
 	testConfigRead(t, b, reqStorage, expected)


### PR DESCRIPTION
# Overview
This commit introduces a new `universe_domain` parameter to the plugin configuration, allowing users to specify the Google Cloud environment for client connections. This enables support for specialized offerings and sovereign controls beyond the default googleapis.com.

Key changes:

- Added `universe_domain` field to the plugin configuration.
- Modified IAM client creation to use the configured `universe_domain`.
- Updated credentials parsing to utilize `cloud.google.com/go/auth/credentials.DetectDefault` and support local-signing JWT generation.
- Adjusted token generation to use `cloud.google.com/go/auth/credentials.DetectDefault` for credential handling.

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #242](https://github.com/hashicorp/vault-plugin-secrets-gcp/issues/242)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
