### PR TITLE
Forward Performance Standby requests when configuring root credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 BUG FIXES:
-* Forward Performance Secondary requests when configuring root credentials: [GH-249](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/249)
+* Fix a panic when a performance standby node attempts to write/update config: [GH-249](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/249)
 
 ## v0.21.2
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## v0.21.3
+
 BUG FIXES:
 * Fix a panic when a performance standby node attempts to write/update config: [GH-249](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/249)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 BUG FIXES:
-* Forward Performance Secondary requests when configuring root credentials: [GH-246](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/246)
+* Forward Performance Secondary requests when configuring root credentials: [GH-249](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/249)
 
 ## v0.21.2
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUG FIXES:
+* Forward Performance Secondary requests when configuring root credentials: [GH-246](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/246)
+
 ## v0.21.2
 IMPROVEMENTS:
 * Update dependencies:

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -58,6 +58,8 @@ func pathConfig(b *backend) *framework.Path {
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
 				},
+				ForwardPerformanceSecondary: true,
+				ForwardPerformanceStandby:   true,
 			},
 		},
 


### PR DESCRIPTION
Fixes a bug where Performance Secondaries panic when they attempt to de-register / register jobs to the RM, since the RM is nil on Perf Secondaries. This fix appropriately forwards such requests to the Primary node in the cluster.