### PR TITLE
retry verifySecretServiceKeyExists()

### DIFF
--- a/plugin/secrets_service_account_key.go
+++ b/plugin/secrets_service_account_key.go
@@ -55,7 +55,7 @@ func (b *backend) secretKeyRenew(ctx context.Context, req *logical.Request, d *f
 	// available in the service account keys API, so we retry a few times.
 	r, err := retryWithExponentialBackoff(ctx, func() (interface{}, bool, error) {
 		resp, err := b.verifySecretServiceKeyExists(ctx, req)
-		if err != nil {
+		if err != nil || (resp != nil && resp.IsError()) {
 			return resp, false, err
 		}
 		if resp == nil {

--- a/plugin/secrets_service_account_key.go
+++ b/plugin/secrets_service_account_key.go
@@ -51,13 +51,22 @@ func secretServiceAccountKey(b *backend) *framework.Secret {
 }
 
 func (b *backend) secretKeyRenew(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	resp, err := b.verifySecretServiceKeyExists(ctx, req)
+	// If the service account was recently created, it may not be immediately
+	// available in the service account keys API, so we retry a few times.
+	r, err := retryWithExponentialBackoff(ctx, func() (interface{}, bool, error) {
+		resp, err := b.verifySecretServiceKeyExists(ctx, req)
+		if err != nil {
+			return resp, false, err
+		}
+		if resp == nil {
+			resp = &logical.Response{}
+		}
+		return resp, true, nil
+	})
 	if err != nil {
-		return resp, err
+		return nil, err
 	}
-	if resp == nil {
-		resp = &logical.Response{}
-	}
+	resp := r.(*logical.Response)
 	cfg, err := getConfig(ctx, req.Storage)
 	if err != nil {
 		return nil, err
@@ -204,8 +213,9 @@ func (b *backend) createServiceAccountKeySecret(ctx context.Context, s logical.S
 	return resp, nil
 }
 
-const pathServiceAccountKeySyn = `Generate a service account private key secret.`
-const pathServiceAccountKeyDesc = `
+const (
+	pathServiceAccountKeySyn  = `Generate a service account private key secret.`
+	pathServiceAccountKeyDesc = `
 This path will generate a new service account key for accessing GCP APIs.
 
 Either specify "roleset/my-roleset" or "static/my-account" to generate a key corresponding
@@ -214,3 +224,4 @@ to a roleset or static account respectively.
 Please see backend documentation for more information:
 https://www.vaultproject.io/docs/secrets/gcp/index.html
 `
+)

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -9,6 +9,7 @@ The following BATs tests can be used to test basic functionality of the GCP Secr
 * Docker
 * Vault CLI installed
 * GCP Project that has a service account w/ [required permissions](https://www.vaultproject.io/docs/secrets/gcp#required-permissions)
+* gcloud CLI installed
 
 ### GCP Testing
 
@@ -17,17 +18,17 @@ First, set the following env variables from your GCP project
 * SERVICE_ACCOUNT_ID
 * GOOGLE_APPLICATION_CREDENTIALS (path to service account credentials JSON file)
 * GOOGLE_CLOUD_PROJECT_ID
-* GOOGLE_CLOUD_PROJECT_NAME (used to write bindings file)
 * GOOGLE_REGION
 
 Run the tests:
+
 ```bash
-$ cd ./tests/acceptance
-$ bats gcp-secrets.bats
+bats ./tests/acceptance/gcp-secrets.bats
 ```
 
 ### Output
-```
+
+```shell
 ✓ Can successfully write GCP Secrets Config
 ✓ Can successfully write token roleset
 ✓ Can successfully generate oAuth tokens
@@ -35,5 +36,5 @@ $ bats gcp-secrets.bats
 ✓ Can successfully generate dynamic keys
 ✓ Can successfully write access token static account
 ✓ Can successfully write service account key static account
+✓ Can renew lease for a service account key for a new service account (10x)
 ```
-

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -28,7 +28,7 @@ bats ./tests/acceptance/gcp-secrets.bats
 
 ### Output
 
-```shell
+```
 ✓ Can successfully write GCP Secrets Config
 ✓ Can successfully write token roleset
 ✓ Can successfully generate oAuth tokens

--- a/tests/acceptance/gcp-secrets.bats
+++ b/tests/acceptance/gcp-secrets.bats
@@ -176,13 +176,13 @@ teardown(){
         credentials=@creds.json
 
     bats::on_failure() {
-        for x in $(seq 1 10); do
+        for x in {1..10}; do
             vault delete ${GCP_MOUNT}/static-account/static-test-${x}
             gcloud iam service-accounts delete test-account-${x}@${GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com --quiet || true
         done
     }
 
-    for x in $(seq 1 10); do
+    for x in {1..10}; do
         GCP_MOUNT=gcp
         GCP_ACCOUNT=test-account-${x}
         gcloud iam service-accounts create ${GCP_ACCOUNT} \

--- a/tests/acceptance/gcp-secrets.bats
+++ b/tests/acceptance/gcp-secrets.bats
@@ -177,7 +177,7 @@ teardown(){
 
     bats::on_failure() {
         for x in {1..10}; do
-            vault delete ${GCP_MOUNT}/static-account/static-test-${x}
+            vault delete gcp/static-account/static-test-${x}
             gcloud iam service-accounts delete test-account-${x}@${GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com --quiet || true
         done
     }


### PR DESCRIPTION
# Overview
Smooths over an eventual consistency issues with the static-account flow. Targeting the scenario where a user creates a GCP service account (outside of Vault), then immediately requests Vault to create a key and renew the lease for it, but the key API doesn't see the service account right away. This manifests when using Vault Agent, since it starts a LifetimeWatcher which immediately renews the lease.

# Design of Change
Adding `retryWithExponentialBackoff()` around the `verifySecretServiceKeyExists()` call, and the `getServiceAccount()` and `createIamBindings()` in the`createStaticAccount()` flow.

<details>
<summary>Example without this patch:</summary>

```shell
GCP_MOUNT=gcp
gcloud iam service-accounts create dev-account \
  --description="testing gcp secrets" \
  --display-name="dev-account"

vault write ${GCP_MOUNT}/static-account/static-test \
  service_account_email="dev-account@${GCP_PROJECT}.iam.gserviceaccount.com" \
  secret_type="service_account_key"  \
  bindings=@mybindings.hcl

LEASE_ID=$(vault read -format=json ${GCP_MOUNT}/static-account/static-test/key | jq -r .lease_id)

vault lease renew ${LEASE_ID}

vault lease revoke ${LEASE_ID}

vault delete ${GCP_MOUNT}/static-account/static-test

gcloud iam service-accounts delete dev-account@${GCP_PROJECT}.iam.gserviceaccount.com
Created service account [dev-account].
Success! Data written to: gcp/static-account/static-test
Error renewing gcp/static-account/static-test/key/cuux2HVC6dqdOmIfibCDKT3h: Error making API request.

URL: PUT https://127.0.0.1:8248/v1/sys/leases/renew
Code: 400. Errors:

* failed to renew entry: resp: &logical.Response{Secret:*logical.Secret{LeaseOptions:logical.LeaseOptions{TTL:0, MaxTTL:0, Renewable:true, Increment:0, IssueTime:time.Date(2025, time.July, 17, 18, 0, 36, 187859000, time.Local)}, InternalData:map[string]interface {}{"key_name":"projects/hc-a019ca61accf4d1ba67b1d0531f/serviceAccounts/dev-account@hc-0000000000000000000000000000.iam.gserviceaccount.com/keys/8a346e852d472f1a5c78761beec147ea076015f9", "secret_type":"service_account_key", "static_account":"static-test", "static_account_bindings":"PoXQQP+Wy4yrU31Im+M8loZhTAFIqUTAIpESCjc4ihw="}, LeaseID:""}, Auth:<nil>, Data:map[string]interface {}{"error":"could not confirm key still exists in GCP: googleapi: Error 404: Service account key 8a346e852d472f1a5c78761beec147ea076015f9 does not exist., notFound"}, Redirect:"", Warnings:[]string(nil), WrapInfo:(*wrapping.ResponseWrapInfo)(nil), Headers:map[string][]string(nil), MountType:""} err: %!w(<nil>)
All revocation operations queued successfully!
Success! Data deleted (if it existed) at: gcp/static-account/static-test
You are about to delete service account [dev-account@hc-0000000000000000000000000000.iam.gserviceaccount.com]

Do you want to continue (Y/n)?  Y

deleted service account [dev-account@hc-0000000000000000000000000000.iam.gserviceaccount.com]
```
</details>

<details>
<summary>Example with this patch:</summary>

```shell
GCP_MOUNT=gcp-dev
gcloud iam service-accounts create dev-account \
  --description="testing gcp secrets" \
  --display-name="dev-account"

vault write ${GCP_MOUNT}/static-account/static-test \
  service_account_email="dev-account@${GCP_PROJECT}.iam.gserviceaccount.com" \
  secret_type="service_account_key"  \
  bindings=@mybindings.hcl

LEASE_ID=$(vault read -format=json ${GCP_MOUNT}/static-account/static-test/key | jq -r .lease_id)

vault lease renew ${LEASE_ID}

vault lease revoke ${LEASE_ID}

vault delete ${GCP_MOUNT}/static-account/static-test

gcloud iam service-accounts delete dev-account@${GCP_PROJECT}.iam.gserviceaccount.com
Created service account [dev-account].
Success! Data written to: gcp-dev/static-account/static-test
Key                Value
---                -----
lease_id           gcp-dev/static-account/static-test/key/rlle7hpPzd9jFawkCYGVHPLZ
lease_duration     768h
lease_renewable    true
All revocation operations queued successfully!
Success! Data deleted (if it existed) at: gcp-dev/static-account/static-test
You are about to delete service account [dev-account@hc-0000000000000000000000000000.iam.gserviceaccount.com]

Do you want to continue (Y/n)?  y

deleted service account [dev-account@hc-0000000000000000000000000000.iam.gserviceaccount.com]

```
</details>

# Related Issues/Pull Requests
- [x] [PR #257](https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/257)

# Contributor Checklist
- [-] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
- [x] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
- [x] Backwards compatible
