### PR TITLE
Backport eventual consistency patches to the 1.19 branch

### DIFF
--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -9,6 +9,7 @@ The following BATs tests can be used to test basic functionality of the GCP Secr
 * Docker
 * Vault CLI installed
 * GCP Project that has a service account w/ [required permissions](https://www.vaultproject.io/docs/secrets/gcp#required-permissions)
+* gcloud CLI installed
 
 ### GCP Testing
 
@@ -17,16 +18,16 @@ First, set the following env variables from your GCP project
 * SERVICE_ACCOUNT_ID
 * GOOGLE_APPLICATION_CREDENTIALS (path to service account credentials JSON file)
 * GOOGLE_CLOUD_PROJECT_ID
-* GOOGLE_CLOUD_PROJECT_NAME (used to write bindings file)
 * GOOGLE_REGION
 
 Run the tests:
+
 ```bash
-$ cd ./tests/acceptance
-$ bats gcp-secrets.bats
+bats ./tests/acceptance/gcp-secrets.bats
 ```
 
 ### Output
+
 ```
 ✓ Can successfully write GCP Secrets Config
 ✓ Can successfully write token roleset
@@ -35,5 +36,5 @@ $ bats gcp-secrets.bats
 ✓ Can successfully generate dynamic keys
 ✓ Can successfully write access token static account
 ✓ Can successfully write service account key static account
+✓ Can renew lease for a service account key for a new service account (10x)
 ```
-

--- a/tests/acceptance/gcp-secrets.bats
+++ b/tests/acceptance/gcp-secrets.bats
@@ -18,12 +18,6 @@ then
     exit 1
 fi
 
-if [[ -z $GOOGLE_CLOUD_PROJECT_NAME ]]
-then
-    echo "GOOGLE_CLOUD_PROJECT_NAME env is not set. Exiting.."
-    exit 1
-fi
-
 if [[ -z $GOOGLE_APPLICATION_CREDENTIALS ]]
 then
     echo "GOOGLE_APPLICATION_CREDENTIALS env is not set. Exiting.."
@@ -35,11 +29,11 @@ export SETUP_TEARDOWN_OUTFILE=/tmp/output.log
 setup(){
     { # Braces used to redirect all setup logs.
     # 1. Write bindings file.
-    cat > tests/acceptance/configs/mybindings.hcl <<EOF
-    resource "//cloudresourcemanager.googleapis.com/projects/${GOOGLE_CLOUD_PROJECT_NAME}" {
-        roles = ["roles/viewer"]
-    }
-    EOF
+    cat <<EOF > tests/acceptance/configs/mybindings.hcl
+resource "//cloudresourcemanager.googleapis.com/projects/${GOOGLE_CLOUD_PROJECT_ID}" {
+    roles = ["roles/viewer"]
+}
+EOF
     # 2. Copy credentials file.
     cp $GOOGLE_APPLICATION_CREDENTIALS ./creds.json
 
@@ -175,4 +169,39 @@ teardown(){
           token_scopes="https://www.googleapis.com/auth/cloud-platform" \
           bindings=@tests/acceptance/configs/mybindings.hcl
     [ "${status?}" -eq 0 ]
+}
+
+@test "Can renew lease for a service account key for a new service account (10x)" {
+    vault write gcp/config \
+        credentials=@creds.json
+
+    bats::on_failure() {
+        for x in {1..10}; do
+            vault delete gcp/static-account/static-test-${x}
+            gcloud iam service-accounts delete test-account-${x}@${GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com --quiet || true
+        done
+    }
+
+    for x in {1..10}; do
+        GCP_MOUNT=gcp
+        GCP_ACCOUNT=test-account-${x}
+        gcloud iam service-accounts create ${GCP_ACCOUNT} \
+            --description="testing gcp secrets" \
+            --display-name="${GCP_ACCOUNT}"
+
+        vault write ${GCP_MOUNT}/static-account/static-test-${x} \
+            service_account_email="${GCP_ACCOUNT}@${GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com" \
+            secret_type="service_account_key"  \
+            bindings=@tests/acceptance/configs/mybindings.hcl
+
+        LEASE_ID=$(vault read -format=json ${GCP_MOUNT}/static-account/static-test-${x}/key | jq -r .lease_id)
+
+        vault lease renew ${LEASE_ID}
+
+        vault lease revoke ${LEASE_ID}
+
+        vault delete ${GCP_MOUNT}/static-account/static-test-${x}
+
+        gcloud iam service-accounts delete ${GCP_ACCOUNT}@${GOOGLE_CLOUD_PROJECT_ID}.iam.gserviceaccount.com --quiet
+    done
 }


### PR DESCRIPTION
# Overview
Backporting #257, #258. #260 to the Vault 1.19 branch

# Design of Change
How was this change implemented?

# Related Issues/Pull Requests
[ ] [Issue #1234](https://github.com/hashicorp/vault/issues/1234)
[ ] [PR #1234](https://github.com/hashicorp/vault/pr/1234)

# Contributor Checklist
[ ] Add relevant docs to upstream Vault repository, or sufficient reasoning why docs won’t be added yet
[My Docs PR Link](link)
[Example](https://github.com/hashicorp/vault/commit/2715f5cec982aabc7b7a6ae878c547f6f475bba6)
[ ] Add output for any tests not ran in CI to the PR description (eg, acceptance tests)
[ ] Backwards compatible
