### PR TITLE
Add missing OpenAPI metadata to the API endpoints

### DIFF
--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -47,15 +47,67 @@ func pathConfig(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathConfigRead,
+				Summary:  "Return the GCP secrets engine configuration.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb:   "read",
 					OperationSuffix: "configuration",
 				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"ttl": {
+								Type:        framework.TypeInt,
+								Description: "Default lease for generated keys, in seconds.",
+							},
+							"max_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Maximum lifetime of generated keys, in seconds.",
+							},
+							"service_account_email": {
+								Type:        framework.TypeString,
+								Description: "Email ID of the service account used for Workload Identity Federation.",
+							},
+							"identity_token_audience": {
+								Type:        framework.TypeString,
+								Description: "Audience of plugin identity tokens.",
+							},
+							"identity_token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Time-to-live of plugin identity tokens, in seconds.",
+							},
+							"rotation_schedule": {
+								Type:        framework.TypeString,
+								Description: "CRON-style schedule for automated root credential rotation.",
+							},
+							"rotation_window": {
+								Type:        framework.TypeInt,
+								Description: "Time window in seconds for automated rotation to complete.",
+							},
+							"rotation_period": {
+								Type:        framework.TypeInt,
+								Description: "Period in seconds between automated root credential rotations.",
+							},
+							"disable_automated_rotation": {
+								Type:        framework.TypeBool,
+								Description: "Whether automated rotation is disabled.",
+							},
+							"rotation_policy": {
+								Type:        framework.TypeString,
+								Description: "Name of the rotation policy for automated root credential rotation.",
+							},
+						},
+					}},
+				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathConfigWrite,
+				Summary:  "Configure the GCP secrets engine.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationVerb: "configure",
+				},
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
 				},
 				ForwardPerformanceSecondary: true,
 				ForwardPerformanceStandby:   true,
@@ -222,9 +274,7 @@ func writeConfig(ctx context.Context, storage logical.Storage, config config) (e
 	return nil
 }
 
-const pathConfigHelpSyn = `
-Configure the GCP backend.
-`
+const pathConfigHelpSyn = `Configure the GCP secrets engine.`
 
 const pathConfigHelpDesc = `
 The GCP backend requires credentials for managing IAM service accounts and keys

--- a/plugin/path_config_rotate_root.go
+++ b/plugin/path_config_rotate_root.go
@@ -27,6 +27,18 @@ func pathConfigRotateRoot(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathConfigRotateRootWrite,
+				Summary:                     "Rotate the root credentials for the GCP secrets engine.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_id": {
+								Type:        framework.TypeString,
+								Description: "ID of the new GCP service account key.",
+							},
+						},
+					}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},
@@ -141,9 +153,7 @@ func (b *backend) rotateRootCredential(ctx context.Context, req *logical.Request
 	return nil
 }
 
-const pathConfigRotateRootHelpSyn = `
-Request to rotate the GCP credentials used by Vault
-`
+const pathConfigRotateRootHelpSyn = `Request to rotate the GCP credentials used by Vault.`
 
 const pathConfigRotateRootHelpDesc = `
 This path attempts to rotate the GCP service account credentials used by Vault

--- a/plugin/path_config_rotate_root.go
+++ b/plugin/path_config_rotate_root.go
@@ -26,8 +26,8 @@ func pathConfigRotateRoot(b *backend) *framework.Path {
 
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathConfigRotateRootWrite,
-				Summary:                     "Rotate the root credentials for the GCP secrets engine.",
+				Callback: b.pathConfigRotateRootWrite,
+				Summary:  "Rotate the root credentials for the GCP secrets engine.",
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",

--- a/plugin/path_impersonated_account.go
+++ b/plugin/path_impersonated_account.go
@@ -46,15 +46,51 @@ func pathImpersonatedAccount(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountDelete,
+				Summary:  "Delete an impersonated account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountRead,
+				Summary:  "Return an impersonated account.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"service_account_project": {
+								Type:        framework.TypeString,
+								Description: "GCP project of the impersonated service account.",
+							},
+							"service_account_email": {
+								Type:        framework.TypeString,
+								Description: "Email of the impersonated GCP service account.",
+							},
+							"token_scopes": {
+								Type:        framework.TypeSlice,
+								Description: "List of OAuth scopes assigned to access tokens.",
+							},
+							"ttl": {
+								Type:        framework.TypeInt,
+								Description: "Lifetime of the token in seconds.",
+							},
+						},
+					}},
+				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountCreate,
+				Summary:  "Create an impersonated account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountUpdate,
+				Summary:  "Update an impersonated account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 		},
 		HelpSynopsis:    pathImpersonatedAccountHelpSyn,
@@ -74,6 +110,18 @@ func pathImpersonatedAccountList(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountList,
+				Summary:  "List all impersonated accounts.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeSlice,
+								Description: "List of impersonated account names.",
+							},
+						},
+					}},
+				},
 			},
 		},
 		HelpSynopsis:    pathListImpersonatedAccountHelpSyn,

--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -30,14 +30,54 @@ func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountAccessToken,
+				Summary:  "Generate an access token for an impersonated account.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "impersonated-account-access-token",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathImpersonatedAccountAccessToken,
+				Summary:  "Generate an access token for an impersonated account.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "impersonated-account-access-token2",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 		},

--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -49,7 +49,7 @@ func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 				Callback: b.pathImpersonatedAccountAccessToken,
 				Summary:  "Generate an access token for an impersonated account.",
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "impersonated-account-access-token2",
+					OperationSuffix: "impersonated-account-access-token",
 				},
 				Responses: map[int][]framework.Response{
 					200: {{
@@ -62,7 +62,7 @@ func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 				Callback: b.pathImpersonatedAccountAccessToken,
 				Summary:  "Generate an access token for an impersonated account.",
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "impersonated-account-access-token",
+					OperationSuffix: "impersonated-account-access-token2",
 				},
 				Responses: map[int][]framework.Response{
 					200: {{

--- a/plugin/path_impersonated_account_secrets.go
+++ b/plugin/path_impersonated_account_secrets.go
@@ -14,6 +14,23 @@ import (
 	"google.golang.org/api/option"
 )
 
+func responseFieldsImpersonatedAccountAccessToken() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"token": {
+			Type:        framework.TypeString,
+			Description: "OAuth2 access token.",
+		},
+		"token_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Remaining lifetime of the token in seconds.",
+		},
+		"expires_at_seconds": {
+			Type:        framework.TypeInt,
+			Description: "Unix timestamp at which the token expires.",
+		},
+	}
+}
+
 func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s/%s/token", impersonatedAccountPathPrefix, framework.GenericNameRegex("name")),
@@ -32,25 +49,12 @@ func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 				Callback: b.pathImpersonatedAccountAccessToken,
 				Summary:  "Generate an access token for an impersonated account.",
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "impersonated-account-access-token",
+					OperationSuffix: "impersonated-account-access-token2",
 				},
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsImpersonatedAccountAccessToken(),
 					}},
 				},
 			},
@@ -58,25 +62,12 @@ func pathImpersonatedAccountSecretAccessToken(b *backend) *framework.Path {
 				Callback: b.pathImpersonatedAccountAccessToken,
 				Summary:  "Generate an access token for an impersonated account.",
 				DisplayAttrs: &framework.DisplayAttributes{
-					OperationSuffix: "impersonated-account-access-token2",
+					OperationSuffix: "impersonated-account-access-token",
 				},
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsImpersonatedAccountAccessToken(),
 					}},
 				},
 			},

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -51,17 +51,57 @@ func pathRoleSet(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetDelete,
+				Summary:  "Delete a roleset.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetRead,
+				Summary:  "Return a roleset.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"secret_type": {
+								Type:        framework.TypeString,
+								Description: "Type of secret generated for this roleset.",
+							},
+							"bindings": {
+								Type:        framework.TypeString,
+								Description: "Bindings configuration for the roleset.",
+							},
+							"service_account_email": {
+								Type:        framework.TypeString,
+								Description: "Email of the GCP service account for this roleset.",
+							},
+							"project": {
+								Type:        framework.TypeString,
+								Description: "GCP project of the roleset service account.",
+							},
+							"token_scopes": {
+								Type:        framework.TypeSlice,
+								Description: "OAuth scopes for access tokens generated under this roleset.",
+							},
+						},
+					}},
+				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
 				Callback:                    b.pathRoleSetCreateUpdate,
+				Summary:                     "Create a roleset.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathRoleSetCreateUpdate,
+				Summary:                     "Update a roleset.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},
@@ -83,6 +123,18 @@ func pathRoleSetList(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetList,
+				Summary:  "List all rolesets.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeSlice,
+								Description: "List of roleset names.",
+							},
+						},
+					}},
+				},
 			},
 		},
 		HelpSynopsis:    pathListRoleSetHelpSyn,
@@ -109,6 +161,10 @@ func pathRoleSetRotateAccount(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathRoleSetRotateAccount,
+				Summary:                     "Rotate the service account for a roleset.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},
@@ -136,6 +192,10 @@ func pathRoleSetRotateKey(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathRoleSetRotateKey,
+				Summary:                     "Rotate the service account key for a roleset.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},

--- a/plugin/path_role_set.go
+++ b/plugin/path_role_set.go
@@ -88,8 +88,8 @@ func pathRoleSet(b *backend) *framework.Path {
 				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
-				Callback:                    b.pathRoleSetCreateUpdate,
-				Summary:                     "Create a roleset.",
+				Callback: b.pathRoleSetCreateUpdate,
+				Summary:  "Create a roleset.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},
@@ -97,8 +97,8 @@ func pathRoleSet(b *backend) *framework.Path {
 				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathRoleSetCreateUpdate,
-				Summary:                     "Update a roleset.",
+				Callback: b.pathRoleSetCreateUpdate,
+				Summary:  "Update a roleset.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},
@@ -160,8 +160,8 @@ func pathRoleSetRotateAccount(b *backend) *framework.Path {
 		ExistenceCheck: b.pathRoleSetExistenceCheck("name"),
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathRoleSetRotateAccount,
-				Summary:                     "Rotate the service account for a roleset.",
+				Callback: b.pathRoleSetRotateAccount,
+				Summary:  "Rotate the service account for a roleset.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},
@@ -191,8 +191,8 @@ func pathRoleSetRotateKey(b *backend) *framework.Path {
 		ExistenceCheck: b.pathRoleSetExistenceCheck("name"),
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathRoleSetRotateKey,
-				Summary:                     "Rotate the service account key for a roleset.",
+				Callback: b.pathRoleSetRotateKey,
+				Summary:  "Rotate the service account key for a roleset.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},

--- a/plugin/path_role_set_secrets.go
+++ b/plugin/path_role_set_secrets.go
@@ -59,14 +59,54 @@ func pathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
+				Summary:  "Generate a service account key for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-key2",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_data": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded private key data for the service account key.",
+							},
+							"key_algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm used to generate the service account key.",
+							},
+							"key_type": {
+								Type:        framework.TypeString,
+								Description: "Private key type of the service account key.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
+				Summary:  "Generate a service account key for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-key",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_data": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded private key data for the service account key.",
+							},
+							"key_algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm used to generate the service account key.",
+							},
+							"key_type": {
+								Type:        framework.TypeString,
+								Description: "Private key type of the service account key.",
+							},
+						},
+					}},
 				},
 			},
 		},
@@ -88,14 +128,54 @@ func deprecatedPathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
+				Summary:  "Generate a service account key for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-key4",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_data": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded private key data for the service account key.",
+							},
+							"key_algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm used to generate the service account key.",
+							},
+							"key_type": {
+								Type:        framework.TypeString,
+								Description: "Private key type of the service account key.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretKey,
+				Summary:  "Generate a service account key for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-key3",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_data": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded private key data for the service account key.",
+							},
+							"key_algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm used to generate the service account key.",
+							},
+							"key_type": {
+								Type:        framework.TypeString,
+								Description: "Private key type of the service account key.",
+							},
+						},
+					}},
 				},
 			},
 		},
@@ -116,14 +196,54 @@ func pathRoleSetSecretAccessToken(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
+				Summary:  "Generate an access token for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-access-token2",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
+				Summary:  "Generate an access token for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-access-token",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 		},
@@ -145,14 +265,54 @@ func deprecatedPathRoleSetSecretAccessToken(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
+				Summary:  "Generate an access token for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-access-token4",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathRoleSetSecretAccessToken,
+				Summary:  "Generate an access token for a roleset.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "roleset-access-token3",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 		},

--- a/plugin/path_role_set_secrets.go
+++ b/plugin/path_role_set_secrets.go
@@ -11,6 +11,40 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+func responseFieldsRoleSetKey() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"private_key_data": {
+			Type:        framework.TypeString,
+			Description: "Base64-encoded private key data for the service account key.",
+		},
+		"key_algorithm": {
+			Type:        framework.TypeString,
+			Description: "Algorithm used to generate the service account key.",
+		},
+		"key_type": {
+			Type:        framework.TypeString,
+			Description: "Private key type of the service account key.",
+		},
+	}
+}
+
+func responseFieldsRoleSetAccessToken() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"token": {
+			Type:        framework.TypeString,
+			Description: "OAuth2 access token.",
+		},
+		"token_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Remaining lifetime of the token in seconds.",
+		},
+		"expires_at_seconds": {
+			Type:        framework.TypeInt,
+			Description: "Unix timestamp at which the token expires.",
+		},
+	}
+}
+
 func fieldSchemaRoleSetServiceAccountKey() map[string]*framework.FieldSchema {
 	return map[string]*framework.FieldSchema{
 		"roleset": {
@@ -66,20 +100,7 @@ func pathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"private_key_data": {
-								Type:        framework.TypeString,
-								Description: "Base64-encoded private key data for the service account key.",
-							},
-							"key_algorithm": {
-								Type:        framework.TypeString,
-								Description: "Algorithm used to generate the service account key.",
-							},
-							"key_type": {
-								Type:        framework.TypeString,
-								Description: "Private key type of the service account key.",
-							},
-						},
+						Fields:      responseFieldsRoleSetKey(),
 					}},
 				},
 			},
@@ -92,20 +113,7 @@ func pathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"private_key_data": {
-								Type:        framework.TypeString,
-								Description: "Base64-encoded private key data for the service account key.",
-							},
-							"key_algorithm": {
-								Type:        framework.TypeString,
-								Description: "Algorithm used to generate the service account key.",
-							},
-							"key_type": {
-								Type:        framework.TypeString,
-								Description: "Private key type of the service account key.",
-							},
-						},
+						Fields:      responseFieldsRoleSetKey(),
 					}},
 				},
 			},
@@ -135,20 +143,7 @@ func deprecatedPathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"private_key_data": {
-								Type:        framework.TypeString,
-								Description: "Base64-encoded private key data for the service account key.",
-							},
-							"key_algorithm": {
-								Type:        framework.TypeString,
-								Description: "Algorithm used to generate the service account key.",
-							},
-							"key_type": {
-								Type:        framework.TypeString,
-								Description: "Private key type of the service account key.",
-							},
-						},
+						Fields:      responseFieldsRoleSetKey(),
 					}},
 				},
 			},
@@ -161,20 +156,7 @@ func deprecatedPathRoleSetSecretServiceAccountKey(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"private_key_data": {
-								Type:        framework.TypeString,
-								Description: "Base64-encoded private key data for the service account key.",
-							},
-							"key_algorithm": {
-								Type:        framework.TypeString,
-								Description: "Algorithm used to generate the service account key.",
-							},
-							"key_type": {
-								Type:        framework.TypeString,
-								Description: "Private key type of the service account key.",
-							},
-						},
+						Fields:      responseFieldsRoleSetKey(),
 					}},
 				},
 			},
@@ -203,20 +185,7 @@ func pathRoleSetSecretAccessToken(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsRoleSetAccessToken(),
 					}},
 				},
 			},
@@ -229,20 +198,7 @@ func pathRoleSetSecretAccessToken(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsRoleSetAccessToken(),
 					}},
 				},
 			},
@@ -272,20 +228,7 @@ func deprecatedPathRoleSetSecretAccessToken(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsRoleSetAccessToken(),
 					}},
 				},
 			},
@@ -298,20 +241,7 @@ func deprecatedPathRoleSetSecretAccessToken(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsRoleSetAccessToken(),
 					}},
 				},
 			},

--- a/plugin/path_static_account.go
+++ b/plugin/path_static_account.go
@@ -53,17 +53,57 @@ func pathStaticAccount(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.DeleteOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountDelete,
+				Summary:  "Delete a static account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 			},
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountRead,
+				Summary:  "Return a static account.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"service_account_project": {
+								Type:        framework.TypeString,
+								Description: "GCP project of the static service account.",
+							},
+							"service_account_email": {
+								Type:        framework.TypeString,
+								Description: "Email of the static GCP service account.",
+							},
+							"secret_type": {
+								Type:        framework.TypeString,
+								Description: "Type of secret generated for this static account.",
+							},
+							"bindings": {
+								Type:        framework.TypeString,
+								Description: "Bindings configuration for the static account.",
+							},
+							"token_scopes": {
+								Type:        framework.TypeSlice,
+								Description: "OAuth scopes for access tokens generated under this static account.",
+							},
+						},
+					}},
+				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
 				Callback:                    b.pathStaticAccountCreate,
+				Summary:                     "Create a static account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathStaticAccountUpdate,
+				Summary:                     "Update a static account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},
@@ -85,6 +125,18 @@ func pathStaticAccountList(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ListOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountList,
+				Summary:  "List all static accounts.",
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"keys": {
+								Type:        framework.TypeSlice,
+								Description: "List of static account names.",
+							},
+						},
+					}},
+				},
 			},
 		},
 		HelpSynopsis:    pathListStaticAccountHelpSyn,

--- a/plugin/path_static_account.go
+++ b/plugin/path_static_account.go
@@ -90,8 +90,8 @@ func pathStaticAccount(b *backend) *framework.Path {
 				},
 			},
 			logical.CreateOperation: &framework.PathOperation{
-				Callback:                    b.pathStaticAccountCreate,
-				Summary:                     "Create a static account.",
+				Callback: b.pathStaticAccountCreate,
+				Summary:  "Create a static account.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},
@@ -99,8 +99,8 @@ func pathStaticAccount(b *backend) *framework.Path {
 				ForwardPerformanceSecondary: true,
 			},
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathStaticAccountUpdate,
-				Summary:                     "Update a static account.",
+				Callback: b.pathStaticAccountUpdate,
+				Summary:  "Update a static account.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},

--- a/plugin/path_static_account_rotate_key.go
+++ b/plugin/path_static_account_rotate_key.go
@@ -29,6 +29,10 @@ func pathStaticAccountRotateKey(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback:                    b.pathStaticAccountRotateKey,
+				Summary:                     "Rotate the service account key for a static account.",
+				Responses: map[int][]framework.Response{
+					204: {{Description: "No Content"}},
+				},
 				ForwardPerformanceStandby:   true,
 				ForwardPerformanceSecondary: true,
 			},

--- a/plugin/path_static_account_rotate_key.go
+++ b/plugin/path_static_account_rotate_key.go
@@ -28,8 +28,8 @@ func pathStaticAccountRotateKey(b *backend) *framework.Path {
 		ExistenceCheck: b.pathStaticAccountExistenceCheck,
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.UpdateOperation: &framework.PathOperation{
-				Callback:                    b.pathStaticAccountRotateKey,
-				Summary:                     "Rotate the service account key for a static account.",
+				Callback: b.pathStaticAccountRotateKey,
+				Summary:  "Rotate the service account key for a static account.",
 				Responses: map[int][]framework.Response{
 					204: {{Description: "No Content"}},
 				},

--- a/plugin/path_static_account_secrets.go
+++ b/plugin/path_static_account_secrets.go
@@ -44,14 +44,54 @@ func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountSecretKey,
+				Summary:  "Generate a service account key for a static account.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "static-account-key2",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_data": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded private key data for the service account key.",
+							},
+							"key_algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm used to generate the service account key.",
+							},
+							"key_type": {
+								Type:        framework.TypeString,
+								Description: "Private key type of the service account key.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountSecretKey,
+				Summary:  "Generate a service account key for a static account.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "static-account-key",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"private_key_data": {
+								Type:        framework.TypeString,
+								Description: "Base64-encoded private key data for the service account key.",
+							},
+							"key_algorithm": {
+								Type:        framework.TypeString,
+								Description: "Algorithm used to generate the service account key.",
+							},
+							"key_type": {
+								Type:        framework.TypeString,
+								Description: "Private key type of the service account key.",
+							},
+						},
+					}},
 				},
 			},
 		},
@@ -76,14 +116,54 @@ func pathStaticAccountSecretAccessToken(b *backend) *framework.Path {
 		Operations: map[logical.Operation]framework.OperationHandler{
 			logical.ReadOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountAccessToken,
+				Summary:  "Generate an access token for a static account.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "static-account-access-token2",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 			logical.UpdateOperation: &framework.PathOperation{
 				Callback: b.pathStaticAccountAccessToken,
+				Summary:  "Generate an access token for a static account.",
 				DisplayAttrs: &framework.DisplayAttributes{
 					OperationSuffix: "static-account-access-token",
+				},
+				Responses: map[int][]framework.Response{
+					200: {{
+						Description: "OK",
+						Fields: map[string]*framework.FieldSchema{
+							"token": {
+								Type:        framework.TypeString,
+								Description: "OAuth2 access token.",
+							},
+							"token_ttl": {
+								Type:        framework.TypeInt,
+								Description: "Remaining lifetime of the token in seconds.",
+							},
+							"expires_at_seconds": {
+								Type:        framework.TypeInt,
+								Description: "Unix timestamp at which the token expires.",
+							},
+						},
+					}},
 				},
 			},
 		},

--- a/plugin/path_static_account_secrets.go
+++ b/plugin/path_static_account_secrets.go
@@ -11,6 +11,40 @@ import (
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
+func responseFieldsStaticAccountKey() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"private_key_data": {
+			Type:        framework.TypeString,
+			Description: "Base64-encoded private key data for the service account key.",
+		},
+		"key_algorithm": {
+			Type:        framework.TypeString,
+			Description: "Algorithm used to generate the service account key.",
+		},
+		"key_type": {
+			Type:        framework.TypeString,
+			Description: "Private key type of the service account key.",
+		},
+	}
+}
+
+func responseFieldsStaticAccountAccessToken() map[string]*framework.FieldSchema {
+	return map[string]*framework.FieldSchema{
+		"token": {
+			Type:        framework.TypeString,
+			Description: "OAuth2 access token.",
+		},
+		"token_ttl": {
+			Type:        framework.TypeInt,
+			Description: "Remaining lifetime of the token in seconds.",
+		},
+		"expires_at_seconds": {
+			Type:        framework.TypeInt,
+			Description: "Unix timestamp at which the token expires.",
+		},
+	}
+}
+
 func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
 	return &framework.Path{
 		Pattern: fmt.Sprintf("%s/%s/key", staticAccountPathPrefix, framework.GenericNameRegex("name")),
@@ -51,20 +85,7 @@ func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"private_key_data": {
-								Type:        framework.TypeString,
-								Description: "Base64-encoded private key data for the service account key.",
-							},
-							"key_algorithm": {
-								Type:        framework.TypeString,
-								Description: "Algorithm used to generate the service account key.",
-							},
-							"key_type": {
-								Type:        framework.TypeString,
-								Description: "Private key type of the service account key.",
-							},
-						},
+						Fields:      responseFieldsStaticAccountKey(),
 					}},
 				},
 			},
@@ -77,20 +98,7 @@ func pathStaticAccountSecretServiceAccountKey(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"private_key_data": {
-								Type:        framework.TypeString,
-								Description: "Base64-encoded private key data for the service account key.",
-							},
-							"key_algorithm": {
-								Type:        framework.TypeString,
-								Description: "Algorithm used to generate the service account key.",
-							},
-							"key_type": {
-								Type:        framework.TypeString,
-								Description: "Private key type of the service account key.",
-							},
-						},
+						Fields:      responseFieldsStaticAccountKey(),
 					}},
 				},
 			},
@@ -123,20 +131,7 @@ func pathStaticAccountSecretAccessToken(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsStaticAccountAccessToken(),
 					}},
 				},
 			},
@@ -149,20 +144,7 @@ func pathStaticAccountSecretAccessToken(b *backend) *framework.Path {
 				Responses: map[int][]framework.Response{
 					200: {{
 						Description: "OK",
-						Fields: map[string]*framework.FieldSchema{
-							"token": {
-								Type:        framework.TypeString,
-								Description: "OAuth2 access token.",
-							},
-							"token_ttl": {
-								Type:        framework.TypeInt,
-								Description: "Remaining lifetime of the token in seconds.",
-							},
-							"expires_at_seconds": {
-								Type:        framework.TypeInt,
-								Description: "Unix timestamp at which the token expires.",
-							},
-						},
+						Fields:      responseFieldsStaticAccountAccessToken(),
 					}},
 				},
 			},


### PR DESCRIPTION
Who the change affects or is for (stakeholders)?
The change affects mainly people who use the Vault's UI. With the added fields, they can better understand the endpoints in the gcp secrets plugin.

What is the change?
I added the missing operation summary, path descriptions, and proper typed response schema for the gcp secrets plugin.

Why is the change needed?
The change is needed because many of the plugins in vault were missing path descriptions, operation summaries, and typed response schemas. Many of the response schemas had a bare 200 Description OK response, which is not sufficient.

How does this change affect the user experience (if at all)?
When someone uses the Vault UI, they are able to understand the vault plugins better because they have a detailed description of what the endpoint does and meaningful response schema. With the response schema, they can understand what the endpoint returns.

# Design of Change
How was this change implemented?
I developed an AI skill that automatically adds the HelpSynopsis, Summary, and Response Fields. The Help Synopsis field helps with the path descriptions, and the Help Description and path name are used to come up with the Help Synopsis field. The path name, Operation Prefix, and Operation Suffix are used to come up with the operation summary. For the response schema, the AI skill is able to detect what data types are being added to the response data map, and the skill generates a response schema with those data types. For methods that return a nil, nil, a 204 response code is added.





